### PR TITLE
Feat: [#51] 유저 API 구현( GET, PATCH, DELETE)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
+        "reflect-metadata": "^0.2.2",
         "tslib": "^2.8.1"
       },
       "devDependencies": {
@@ -5015,6 +5016,12 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
+    "reflect-metadata": "^0.2.2",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,8 +40,9 @@ model User {
   lastLoginAt    DateTime? @map("last_login_at")
   createdAt      DateTime  @default(now()) @map("created_at")
   updatedAt      DateTime  @updatedAt @map("updated_at")
+  deletedAt      DateTime? @map("deleted_at")
 
-  company      Company            @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  company      Company           @relation(fields: [companyId], references: [id], onDelete: Cascade)
   contracts    Contract[]
   uploadedDocs ContractDocument[] @relation("UploadedDocuments")
   uploads      Upload[]

--- a/src/auth/auth.routes.ts
+++ b/src/auth/auth.routes.ts
@@ -1,10 +1,17 @@
 import { Router } from 'express';
+import { PrismaClient } from '@prisma/client';
 import AuthController from './controller';
 import validateDto from '../common/utils/validate.dto';
 import { LoginDto } from './dto/login.dto';
+import AuthService from './service';
+import AuthRepository from './repository';
 
-const AuthRoutes = (authController: AuthController): Router => {
+const authRouter = (prisma: PrismaClient): Router => {
   const router = Router();
+
+  const authRepository = new AuthRepository(prisma);
+  const authService = new AuthService(authRepository);
+  const authController = new AuthController(authService);
 
   router.post('/login', validateDto(LoginDto), authController.login);
   router.post('/refresh', authController.refresh);
@@ -12,4 +19,4 @@ const AuthRoutes = (authController: AuthController): Router => {
   return router;
 };
 
-export default AuthRoutes;
+export default authRouter;

--- a/src/index.routes.ts
+++ b/src/index.routes.ts
@@ -8,9 +8,9 @@ import prisma from './common/prisma/client';
 
 const router = express.Router();
 
-router.use('/users', userRouter);
+router.use('/users', userRouter(prisma));
 router.use('/companies', companiesRouter);
-router.use('/auth', authRouter);
+router.use('/auth', authRouter(prisma));
 router.use('/customers', createCustomerRoutes(prisma));
 
 export default router;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import 'reflect-metadata';
 import dotenv from 'dotenv';
 import app from './app';
 

--- a/src/users/controller.ts
+++ b/src/users/controller.ts
@@ -1,18 +1,77 @@
 import { Request, Response, NextFunction } from 'express';
 import UserService from './service';
 import RegisterDto from './dto/create-user.dto';
+import UpdateUserDto from './dto/update-user.dto';
 
 class UserController {
-  static async register(req: Request, res: Response, next: NextFunction) {
+  private readonly userService: UserService;
+
+  constructor(userService: UserService) {
+    this.userService = userService;
+  }
+
+  register = async (req: Request, res: Response, next: NextFunction): Promise<Response | void> => {
     try {
       const userData: RegisterDto = req.body;
-      const newUser = await UserService.register(userData);
-
-      res.status(201).json(newUser);
-    } catch (error) {
-      next(error);
+      const newUser = await this.userService.register(userData);
+      return res.status(201).json(newUser);
+    } catch (error: unknown) {
+      return next(error);
     }
-  }
+  };
+
+  getInfo = async (req: Request, res: Response, next: NextFunction): Promise<Response | void> => {
+    try {
+      const user = req.user as { id: number };
+      const data = await this.userService.getInfo(user.id);
+      return res.json(data);
+    } catch (error: unknown) {
+      return next(error);
+    }
+  };
+
+  updateProfile = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<Response | void> => {
+    try {
+      const user = req.user as { id: number };
+      const updateData: UpdateUserDto = req.body;
+      const updatedUser = await this.userService.updateProfile(user.id, updateData);
+      return res.json(updatedUser);
+    } catch (error: unknown) {
+      return next(error);
+    }
+  };
+
+  deleteUser = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<Response | void> => {
+    try {
+      const user = req.user as { id: number };
+      await this.userService.deleteUser(user.id);
+      return res.status(200).json({ message: '유저 삭제 성공.' });
+    } catch (error: unknown) {
+      return next(error);
+    }
+  };
+
+  deleteUserId = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<Response | void> => {
+    try {
+      const userId = Number(req.params.userId);
+      await this.userService.deleteUser(userId);
+      return res.status(200).json({ message: '유저 삭제 성공.' });
+    } catch (error: unknown) {
+      return next(error);
+    }
+  };
 }
 
 export default UserController;

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -15,15 +15,20 @@ class RegisterDto {
   @IsString({ message: '전화번호는 문자열이어야 합니다.' })
   phoneNumber: string;
 
+  @IsNotEmpty({ message: '비밀번호는 필수 입력 항목입니다.' })
   @IsString()
   @MinLength(10, { message: '비밀번호는 최소 10자 이상이어야 합니다.' })
   @MaxLength(255, { message: '비밀번호는 최대 255자 이하여야 합니다.' })
   password: string;
 
+  @IsNotEmpty({ message: '비밀번호는 필수 입력 항목입니다.' })
   @IsString()
   @MinLength(10, { message: '비밀번호 확인은 최소 10자 이상이어야 합니다.' })
   @MaxLength(255, { message: '비밀번호 확인은 최대 255자 이하여야 합니다.' })
   passwordConfirmation: string;
+
+  @IsString()
+  imageUrl?: string;
 
   @IsString({ message: '기업명은 문자열이어야 합니다.' })
   company: string;
@@ -38,6 +43,7 @@ export interface RegisterResponse {
   email: string;
   employeeNumber: string;
   phoneNumber: string;
+  imageUrl: string | null;
   isAdmin: boolean;
   company: {
     companyCode: string;

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,0 +1,44 @@
+import { IsOptional, IsString, MinLength, MaxLength, Matches } from 'class-validator';
+
+class UpdateUserDto {
+  @IsOptional()
+  @IsString()
+  employeeNumber?: string;
+
+  @IsOptional()
+  @IsString()
+  phoneNumber?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(10, { message: '현재 비밀번호는 최소 10자 이상입니다.' })
+  currentPassword?: string;
+
+  @IsString()
+  @MinLength(10, { message: '비밀번호는 최소 10자 이상이어야 합니다.' })
+  @MaxLength(255, { message: '비밀번호는 최대 255자 이하여야 합니다.' })
+  password?: string;
+
+  @IsString()
+  @MinLength(10, { message: '비밀번호 확인은 최소 10자 이상이어야 합니다.' })
+  @MaxLength(255, { message: '비밀번호 확인은 최대 255자 이하여야 합니다.' })
+  passwordConfirmation?: string;
+
+  @IsOptional()
+  @IsString()
+  imageUrl?: string;
+}
+
+export interface UpdateUserResponse {
+  id: number;
+  name: string;
+  email: string;
+  employeeNumber?: string;
+  phoneNumber?: string;
+  imageUrl?: string;
+  isAdmin: boolean;
+  company: {
+    companyCode: string;
+  };
+}
+export default UpdateUserDto;

--- a/src/users/service.ts
+++ b/src/users/service.ts
@@ -1,12 +1,25 @@
 import bcrypt from 'bcrypt';
 import UserRepository from './repository';
 import RegisterDto, { RegisterResponse } from './dto/create-user.dto';
+import UpdateUserDto, { UpdateUserResponse } from './dto/update-user.dto';
+import {
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+  UnauthorizedError,
+} from '../middlewares/error.middleware';
 
 class UserService {
   /**
    * 회원가입
    */
-  static async register(data: RegisterDto): Promise<RegisterResponse> {
+  private userRepository: UserRepository;
+
+  constructor(userRepository: UserRepository) {
+    this.userRepository = userRepository;
+  }
+
+  async register(data: RegisterDto): Promise<RegisterResponse> {
     const {
       name,
       email,
@@ -14,27 +27,29 @@ class UserService {
       phoneNumber,
       password,
       passwordConfirmation,
+      imageUrl,
       company,
       companyCode,
     } = data;
 
-    const existingUser = await UserRepository.findByEmail(email);
-    if (existingUser) throw new Error('이미 존재하는 이메일입니다.');
+    const existingUser = await this.userRepository.findByEmail(email);
+    if (existingUser) throw new ConflictError('이미 존재하는 이메일입니다.');
 
-    const companyEntity = await UserRepository.findCompanyByNameAndCode(company, companyCode);
-    if (!companyEntity) throw new Error('기업 정보가 유효하지 않습니다.');
+    const companyEntity = await this.userRepository.findCompanyByNameAndCode(company, companyCode);
+    if (!companyEntity) throw new BadRequestError('기업 정보가 유효하지 않습니다.');
 
     if (password !== passwordConfirmation) {
-      throw new Error('비밀번호와 비밀번호 확인이 일치하지 않습니다');
+      throw new BadRequestError('비밀번호와 비밀번호 확인이 일치하지 않습니다');
     }
 
     const hashedPassword = await bcrypt.hash(password, 10);
 
-    const newUser = await UserRepository.createUser({
+    const newUser = await this.userRepository.createUser({
       name,
       email,
       employeeNumber,
       phoneNumber,
+      imageUrl,
       password: hashedPassword,
       companyId: companyEntity.id,
     });
@@ -48,11 +63,78 @@ class UserService {
       email: newUser.email,
       employeeNumber: newUser.employeeNumber,
       phoneNumber: newUser.phoneNumber,
+      imageUrl: newUser.imageUrl,
       isAdmin: newUser.isAdmin,
       company: {
         companyCode: newUser.company.companyCode,
       },
     };
+  }
+
+  async getInfo(userId: number): Promise<RegisterResponse> {
+    const user = await this.userRepository.findWithCompanyByUserId(userId);
+    if (!user) throw new NotFoundError('존재하지 않는 유저입니다.');
+
+    return {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      employeeNumber: user.employeeNumber,
+      phoneNumber: user.phoneNumber,
+      imageUrl: user.imageUrl,
+      isAdmin: user.isAdmin,
+      company: {
+        companyCode: user.company.companyCode,
+      },
+    };
+  }
+
+  async updateProfile(userId: number, data: UpdateUserDto): Promise<UpdateUserResponse> {
+    const user = await this.userRepository.findWithCompanyByUserId(userId);
+    if (!user) throw new NotFoundError('존재하지 않는 유저입니다.');
+
+    // 2차 인증: currentPassword 필수
+    if (data.password || data.phoneNumber || data.employeeNumber) {
+      if (!data.currentPassword) {
+        throw new BadRequestError('현재 비밀번호가 맞지 않습니다.');
+      }
+
+      const isValid = await bcrypt.compare(data.currentPassword, user.password);
+      if (!isValid) throw new UnauthorizedError('비밀번호가 일치하지 않습니다.');
+    }
+    // 비밀번호 검증
+    if (data.password && data.password !== data.passwordConfirmation) {
+      throw new BadRequestError('비밀번호와 비밀번호 확인이 일치하지 않습니다.');
+    }
+
+    const hashedPassword = data.password ? await bcrypt.hash(data.password, 10) : undefined;
+    // 정보 업데이트
+    const updatedUser = await this.userRepository.updateUser(userId, {
+      employeeNumber: data.employeeNumber,
+      phoneNumber: data.phoneNumber,
+      imageUrl: data.imageUrl,
+      ...(hashedPassword ? { password: hashedPassword } : {}),
+    });
+
+    return {
+      id: updatedUser.id,
+      name: updatedUser.name,
+      email: updatedUser.email,
+      employeeNumber: updatedUser.employeeNumber,
+      phoneNumber: updatedUser.phoneNumber,
+      imageUrl: updatedUser.imageUrl ?? undefined,
+      isAdmin: updatedUser.isAdmin,
+      company: {
+        companyCode: updatedUser.company.companyCode,
+      },
+    };
+  }
+
+  async deleteUser(userId: number): Promise<void> {
+    const user = await this.userRepository.findWithCompanyByUserId(userId);
+    if (!user) throw new NotFoundError('존재하지 않는 유저입니다.');
+
+    await this.userRepository.deleteUser(userId);
   }
 }
 


### PR DESCRIPTION
## 📌 작업 개요
- 유저 API
- 내 정보 조회 GET  /users/me
- 내 정보 수정  PATCH /users/me
- 회원 탈퇴 DELETE /users/me
- 유저 삭제 DELETE /users/{userId}

## 🔗 관련 이슈

- Closes  #51 

## ✅ 작업 내용

- controller/service/repository/routes /dto 구현
- 라우터 오류 문제로 의존성을 명확히 분리한 레이어 구조로 변경(테스트 시 문제 없음)
- 유저 스키마 deletedAt 필드 추가
- 논리 삭제로 db에는 정보 남아있고 deletedAt 업데이트 시키는 방식으로 진행. 물리 삭제는 잘 사용하는 방식은 아니라고 함.
- 테스트시 오류가 나서 보니깐 reflect-metadata 패키지가 필요하다 하여 설치 후 main.ts에 import 추가

## 🧪 테스트 내용
<!-- 테스트한 방식과 결과를 명시해주세요. -->
<img width="628" height="398" alt="image" src="https://github.com/user-attachments/assets/c65893c6-3d66-41e6-bc87-f03b1114d03a" />
<img width="528" height="398" alt="image" src="https://github.com/user-attachments/assets/dbb8ac2e-efb3-4c7c-9c4a-fcdd2274d943" />
<img width="759" height="398" alt="image" src="https://github.com/user-attachments/assets/946fa4bc-c8d4-4433-ac09-cfa878562219" />
<img width="626" height="398" alt="image" src="https://github.com/user-attachments/assets/2b00508a-e78d-4ed5-803c-164ca1779d16" />

## ⚠️ 특이사항
<!-- 리뷰어가 참고해야 할 내용이 있다면 작성해주세요. -->
검토 부탁드립니다!