### PR TITLE
fix: [#84] 계약서 인증 부분 수정

### DIFF
--- a/src/contract-documents/contract-documents.routes.ts
+++ b/src/contract-documents/contract-documents.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { PrismaClient } from '@prisma/client';
-import { authenticateJWT } from '../middlewares/auth.middleware';
+import { isAuthenticated } from '../auth/auth';
 import validateDto from '../common/utils/validate.dto';
 import upload from '../middlewares/upload.middleware';
 import ContractDocumentsController from './controller';
@@ -22,7 +22,7 @@ const createContractDocumentsRouter = (prisma: PrismaClient) => {
   // 계약서 목록 조회
   router.get(
     '/',
-    authenticateJWT,
+    isAuthenticated,
     validateDto(GetContractDocumentsDto),
     contractDocumentsController.getContractDocuments,
   );
@@ -30,7 +30,7 @@ const createContractDocumentsRouter = (prisma: PrismaClient) => {
   // 계약서 업로드
   router.post(
     '/upload',
-    authenticateJWT,
+    isAuthenticated,
     upload.array('files', 10), // 최대 10개 파일
     validateDto(UploadContractDocumentDto),
     contractDocumentsController.uploadContractDocuments,
@@ -39,14 +39,14 @@ const createContractDocumentsRouter = (prisma: PrismaClient) => {
   // 계약서 다운로드
   router.get(
     '/:contractDocumentId/download',
-    authenticateJWT,
+    isAuthenticated,
     contractDocumentsController.downloadSingleDocument,
   );
 
   // 여러 계약서 다운로드
   router.post(
     '/download',
-    authenticateJWT,
+    isAuthenticated,
     validateDto(DownloadContractDocumentsDto),
     contractDocumentsController.downloadMultipleDocuments,
   );
@@ -54,7 +54,7 @@ const createContractDocumentsRouter = (prisma: PrismaClient) => {
   // 계약서 수정 (추가/삭제)
   router.patch(
     '/:contractId',
-    authenticateJWT,
+    isAuthenticated,
     upload.array('files', 10),
     validateDto(EditContractDocumentsDto),
     contractDocumentsController.editContractDocuments,

--- a/src/contract-documents/controller.ts
+++ b/src/contract-documents/controller.ts
@@ -1,16 +1,26 @@
 import { Request, Response, NextFunction } from 'express';
-import { AuthRequest } from '../middlewares/auth.middleware';
+import { User } from '@prisma/client'; // Passport에서 사용하는 User 타입
 import ContractDocumentsService from './service';
 import GetContractDocumentsDto from './dto/get-contract-documents.dto';
 import UploadContractDocumentDto from './dto/upload-contract-document.dto';
 import DownloadContractDocumentsDto from './dto/download-contract-documents.dto';
 import EditContractDocumentsDto from './dto/edit-contract-documents.dto';
 
+// Passport 인증 후 Request 타입 정의
+interface AuthenticatedRequest extends Request {
+  user?: User;
+}
+
 export default class ContractDocumentsController {
   // eslint-disable-next-line no-empty-function
   constructor(private readonly contractDocumentsService: ContractDocumentsService) {}
 
-  async getContractDocuments(req: AuthRequest, res: Response, next: NextFunction): Promise<void> {
+  // 화살표 함수를 사용하여 this 바인딩 문제 해결
+  getContractDocuments = async (
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
     try {
       const { companyId } = req.user!;
       const query = req.query as unknown as GetContractDocumentsDto;
@@ -21,13 +31,13 @@ export default class ContractDocumentsController {
     } catch (error) {
       next(error);
     }
-  }
+  };
 
-  async uploadContractDocuments(
-    req: AuthRequest,
+  uploadContractDocuments = async (
+    req: AuthenticatedRequest,
     res: Response,
     next: NextFunction,
-  ): Promise<void> {
+  ): Promise<void> => {
     try {
       const { companyId, id: userId } = req.user!;
       const { contractId } = req.body as UploadContractDocumentDto;
@@ -52,9 +62,13 @@ export default class ContractDocumentsController {
     } catch (error) {
       next(error);
     }
-  }
+  };
 
-  async downloadSingleDocument(req: AuthRequest, res: Response, next: NextFunction): Promise<void> {
+  downloadSingleDocument = async (
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
     try {
       const { companyId } = req.user!;
       const { contractDocumentId } = req.params;
@@ -73,13 +87,13 @@ export default class ContractDocumentsController {
     } catch (error) {
       next(error);
     }
-  }
+  };
 
-  async downloadMultipleDocuments(
-    req: AuthRequest,
+  downloadMultipleDocuments = async (
+    req: AuthenticatedRequest,
     res: Response,
     next: NextFunction,
-  ): Promise<void> {
+  ): Promise<void> => {
     try {
       const { companyId } = req.user!;
       const { contractDocumentIds } = req.body as DownloadContractDocumentsDto;
@@ -95,9 +109,13 @@ export default class ContractDocumentsController {
     } catch (error) {
       next(error);
     }
-  }
+  };
 
-  async editContractDocuments(req: AuthRequest, res: Response, next: NextFunction): Promise<void> {
+  editContractDocuments = async (
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
     try {
       const { companyId, id: userId } = req.user!;
       const { contractId } = req.params;
@@ -116,5 +134,5 @@ export default class ContractDocumentsController {
     } catch (error) {
       next(error);
     }
-  }
+  };
 }


### PR DESCRIPTION
## 📌 작업 개요
- contract-documents.routes.ts 파일 수정 및 controller 파일 수정
## 🔗 관련 이슈
- #84

## ✅ 작업 내용
- contract-documents.routes.ts 파일에서 authenticateJWT → isAuthenticated 변경
- controller.ts 파일에서 AuthRequest → AuthenticatedRequest 인터페이스로 변경,
   Prisma의 User 타입 사용 (Passport가 사용하는 타입과 일치),
   메서드를 화살표 함수로 변경하여 this 바인딩 문제 방지
## 🧪 테스트 내용 

## ⚠️ 특이사항
- 희원님이 말씀해주신 라우터 인증 부분 authenticateJWT → isAuthenticated 변경하였고, 이 변경사항에 맞춰서 controller 파일도 수정했습니다.