### PR TITLE
fix: [#84] controller AuthRequest → Request로 변경

### DIFF
--- a/src/contract-documents/controller.ts
+++ b/src/contract-documents/controller.ts
@@ -1,26 +1,17 @@
 import { Request, Response, NextFunction } from 'express';
-import { User } from '@prisma/client'; // Passport에서 사용하는 User 타입
 import ContractDocumentsService from './service';
 import GetContractDocumentsDto from './dto/get-contract-documents.dto';
 import UploadContractDocumentDto from './dto/upload-contract-document.dto';
 import DownloadContractDocumentsDto from './dto/download-contract-documents.dto';
 import EditContractDocumentsDto from './dto/edit-contract-documents.dto';
 
-// Passport 인증 후 Request 타입 정의
-interface AuthenticatedRequest extends Request {
-  user?: User;
-}
-
+// Express의 기본 Request 타입 사용 (index.d.ts에서 확장된 타입)
 export default class ContractDocumentsController {
   // eslint-disable-next-line no-empty-function
   constructor(private readonly contractDocumentsService: ContractDocumentsService) {}
 
   // 화살표 함수를 사용하여 this 바인딩 문제 해결
-  getContractDocuments = async (
-    req: AuthenticatedRequest,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
+  getContractDocuments = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
       const { companyId } = req.user!;
       const query = req.query as unknown as GetContractDocumentsDto;
@@ -34,7 +25,7 @@ export default class ContractDocumentsController {
   };
 
   uploadContractDocuments = async (
-    req: AuthenticatedRequest,
+    req: Request,
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
@@ -65,7 +56,7 @@ export default class ContractDocumentsController {
   };
 
   downloadSingleDocument = async (
-    req: AuthenticatedRequest,
+    req: Request,
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
@@ -90,7 +81,7 @@ export default class ContractDocumentsController {
   };
 
   downloadMultipleDocuments = async (
-    req: AuthenticatedRequest,
+    req: Request,
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
@@ -112,7 +103,7 @@ export default class ContractDocumentsController {
   };
 
   editContractDocuments = async (
-    req: AuthenticatedRequest,
+    req: Request,
     res: Response,
     next: NextFunction,
   ): Promise<void> => {


### PR DESCRIPTION
## 📌 작업 개요
- controller AuthRequest → Request로 변경
## 🔗 관련 이슈
- #84

## ✅ 작업 내용
- isAuthenticated가 반환하는 req.user의 타입과 Controller에서 기대하는 AuthenticatedRequest의 타입이 맞지 않아서 발생하는 문제 발생

---
그래서 index.d.ts 파일에서 이미 Express.Request와 Express.User 타입을 확장해둬서, 
Controller에서 기본 Request 타입을 사용하면 자동으로 user 속성이 포함이 되기 때문에 req: Request 이런 식으로 바꿈

---

바꾸고 저장하니까 오류는 사라졌네요.
## 🧪 테스트 내용 

## ⚠️ 특이사항
