### PR TITLE
fix: [#86] 회원가입 시 발생한 프론트엔드 연동 이슈 해결 (필드명 companyName으로 수정)

### DIFF
--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,4 +1,12 @@
-import { IsString, IsEmail, MinLength, MaxLength, IsNotEmpty, Length } from 'class-validator';
+import {
+  IsString,
+  IsEmail,
+  IsOptional,
+  MinLength,
+  MaxLength,
+  IsNotEmpty,
+  Length,
+} from 'class-validator';
 
 class RegisterDto {
   @IsNotEmpty({ message: '이름은 필수 입력 항목입니다.' })
@@ -27,11 +35,12 @@ class RegisterDto {
   @MaxLength(255, { message: '비밀번호 확인은 최대 255자 이하여야 합니다.' })
   passwordConfirmation: string;
 
+  @IsOptional()
   @IsString()
   imageUrl?: string;
 
   @IsString({ message: '기업명은 문자열이어야 합니다.' })
-  company: string;
+  companyName: string;
 
   @IsString({ message: '기업코드는 문자열이어야 합니다.' })
   companyCode: string;

--- a/src/users/repository.ts
+++ b/src/users/repository.ts
@@ -22,7 +22,7 @@ class UserRepository {
   }
 
   async findCompanyByNameAndCode(companyName: string, companyCode: string) {
-    return this.prisma.company.findUnique({
+    return this.prisma.company.findFirst({
       where: { companyName, companyCode },
     });
   }

--- a/src/users/service.ts
+++ b/src/users/service.ts
@@ -26,14 +26,17 @@ class UserService {
       password,
       passwordConfirmation,
       imageUrl,
-      company,
+      companyName,
       companyCode,
     } = data;
 
     const existingUser = await this.userRepository.findByEmail(email);
     if (existingUser) throw new ConflictError('이미 존재하는 이메일입니다.');
 
-    const companyEntity = await this.userRepository.findCompanyByNameAndCode(company, companyCode);
+    const companyEntity = await this.userRepository.findCompanyByNameAndCode(
+      companyName,
+      companyCode,
+    );
     if (!companyEntity) throw new BadRequestError('기업 정보가 유효하지 않습니다.');
 
     if (password !== passwordConfirmation) {


### PR DESCRIPTION
## 📌 작업 개요
- 회원가입 시 발생한 프론트엔드 연동 이슈
## 🔗 관련 이슈
- #86 

## ✅ 작업 내용
- 회원가입 시 유효성 검사 오류 발생
- Postman으로 테스트할 때는 문제 없음
- 프론트엔드 코드의 필드명(companyName)과 백엔드 필드명(company)이 달라 발생한 문제 확인
- company → companyName으로 수정하여 필드명 일치
- imageUrl 필드에 @IsOptional() 데코레이터 추가
- 수정 후 회원가입 정상 동작 확인 완료

## 🧪 테스트 내용 
- 브라우저 개발자 도구(Network 탭)에서 요청 확인
<img width="953" height="247" alt="image" src="https://github.com/user-attachments/assets/88ef9a3d-d692-425d-9adc-aca96d1efe50" />

## ⚠️ 특이사항
- 없습니다!