### PR TITLE
fix: 개인 정보 수정 관련 이슈 및 파일 이동에 따른 import 경로 수정

### DIFF
--- a/src/cars/cars.routes.ts
+++ b/src/cars/cars.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { PrismaClient } from '@prisma/client';
-import isAuthenticated from '../auth/auth';
+import isAuthenticated from '../middlewares/passport.middlewares';
 import validateDto from '../common/utils/validate.dto';
 import CarService from './service';
 import CarController, { upload } from './controller';

--- a/src/companies/companies.routes.ts
+++ b/src/companies/companies.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { PrismaClient } from '@prisma/client';
-import isAuthenticated from '../auth/auth';
+import isAuthenticated from '../middlewares/passport.middlewares';
 import CompanyController from './controller';
 import validateDto from '../common/utils/validate.dto';
 import { CreateCompanyDto } from './dto/create-company.dto';

--- a/src/contract-documents/contract-documents.routes.ts
+++ b/src/contract-documents/contract-documents.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { PrismaClient } from '@prisma/client';
-import { isAuthenticated } from '../auth/auth';
+import { isAuthenticated } from '../middlewares/passport.middlewares';
 import validateDto from '../common/utils/validate.dto';
 import upload from '../middlewares/upload.middleware';
 import ContractDocumentsController from './controller';

--- a/src/customers/customers.routes.ts
+++ b/src/customers/customers.routes.ts
@@ -5,7 +5,7 @@ import { CustomerController } from './controller';
 import validateDto from '../common/utils/validate.dto';
 import { CreateCustomerDto } from './dto/create-customer.dto';
 import { UpdateCustomerDto } from './dto/update-customer.dto';
-import { isAuthenticated } from '../auth/auth';
+import { isAuthenticated } from '../middlewares/passport.middlewares';
 
 const storage = multer.memoryStorage();
 const upload = multer({

--- a/src/dashboard/dashboard.routes.ts
+++ b/src/dashboard/dashboard.routes.ts
@@ -3,7 +3,7 @@ import { PrismaClient } from '@prisma/client';
 import { DashboardRepository } from './repository';
 import { DashboardService } from './service';
 import { DashboardController } from './controller';
-import isAuthenticated from '../auth/auth';
+import isAuthenticated from '../middlewares/passport.middlewares';
 
 export const dashboardRouter = (prisma: PrismaClient): Router => {
   const router = Router();

--- a/src/middlewares/passport.middlewares.ts
+++ b/src/middlewares/passport.middlewares.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction, RequestHandler } from 'express';
 import { User } from '@prisma/client';
-import passport from './passport';
+import passport from '../auth/passport';
 
 export const isAuthenticated: RequestHandler = (
   req: Request,

--- a/src/uploads/router.ts
+++ b/src/uploads/router.ts
@@ -6,7 +6,7 @@ import UploadRepository from './repository';
 import { CsvUploadCreateDto } from './dto/csv-upload-create.dto';
 import validateDto from '../common/utils/validate.dto';
 import { csvUploadMiddleware } from '../middlewares/csv-upload.middleware';
-import { isAuthenticated } from '../auth/auth';
+import { isAuthenticated } from '../middlewares/passport.middlewares';
 
 const uploadRouter = (prisma: PrismaClient): Router => {
   const router = Router();

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -14,11 +14,13 @@ class UpdateUserDto {
   @MinLength(8, { message: '현재 비밀번호는 최소 8자 이상입니다.' })
   currentPassword?: string;
 
+  @IsOptional()
   @IsString()
   @MinLength(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
   @MaxLength(255, { message: '비밀번호는 최대 255자 이하여야 합니다.' })
   password?: string;
 
+  @IsOptional()
   @IsString()
   @MinLength(8, { message: '비밀번호 확인은 최소 8자 이상이어야 합니다.' })
   @MaxLength(255, { message: '비밀번호 확인은 최대 255자 이하여야 합니다.' })

--- a/src/users/users.routes.ts
+++ b/src/users/users.routes.ts
@@ -6,7 +6,7 @@ import UserRepository from './repository';
 import validateDto from '../common/utils/validate.dto';
 import RegisterDto from './dto/create-user.dto';
 import UpdateUserDto from './dto/update-user.dto';
-import isAuthenticated from '../auth/auth';
+import isAuthenticated from '../middlewares/passport.middlewares';
 import { authorizeAdmin } from '../middlewares/auth.middleware';
 
 const userRouter = (prisma: PrismaClient): Router => {


### PR DESCRIPTION
## 📌 작업 개요
- 개인 정보 수정 시 무조건 새 비밀번호를 입력해야지 수정되는 이슈 수정
- auth.ts 미들웨어로 이동
## 🔗 관련 이슈
- #108 
## ✅ 작업 내용
- update-user.dto.ts 파일에 비밀번호 부분 @IsOptional() 추가
- 파일 이동 후 passport.middlewares.ts 파일명 변경
- 라우터 import 경로 수정

## 🧪 테스트 내용 
<img width="1068" height="756" alt="image" src="https://github.com/user-attachments/assets/7ad1d498-6f81-42b4-9c23-bf552aa65f8a" />
<img width="1024" height="726" alt="image" src="https://github.com/user-attachments/assets/010efba3-c5dc-4e38-99fc-28efc7674ed1" />

## ⚠️ 특이사항
- 없습니다!