### PR TITLE
Feat: 환경 변수를 사용하여 Firebase Admin SDK 초기화

### DIFF
--- a/src/common/utils/firebase-admin.ts
+++ b/src/common/utils/firebase-admin.ts
@@ -1,0 +1,19 @@
+import * as admin from 'firebase-admin';
+
+// 환경 변수에서 서비스 계정 키를 읽어옵니다.
+const firebaseServiceAccount = process.env.FIREBASE_SERVICE_ACCOUNT;
+
+if (!firebaseServiceAccount) {
+  throw new Error('FIREBASE_SERVICE_ACCOUNT environment variable is not set.');
+}
+
+const serviceAccount = JSON.parse(firebaseServiceAccount);
+
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccount),
+    storageBucket: 'deat-carmate-03.firebasestorage.app',
+  });
+}
+
+export default admin;

--- a/src/common/utils/firebase-admin.ts
+++ b/src/common/utils/firebase-admin.ts
@@ -1,18 +1,24 @@
 import * as admin from 'firebase-admin';
 
 // 환경 변수에서 서비스 계정 키를 읽어옵니다.
-const firebaseServiceAccount = process.env.FIREBASE_SERVICE_ACCOUNT;
+const privateKey = process.env.FIREBASE_PRIVATE_KEY;
+const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+const projectId = process.env.FIREBASE_PROJECT_ID;
+const storageBucket = process.env.FIREBASE_STORAGE_BUCKET;
 
-if (!firebaseServiceAccount) {
-  throw new Error('FIREBASE_SERVICE_ACCOUNT environment variable is not set.');
+// 환경 변수가 모두 설정되었는지 확인
+if (!privateKey || !clientEmail || !projectId || !storageBucket) {
+  throw new Error('Firebase environment variables are not all set.');
 }
-
-const serviceAccount = JSON.parse(firebaseServiceAccount);
 
 if (!admin.apps.length) {
   admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount),
-    storageBucket: 'deat-carmate-03.firebasestorage.app',
+    credential: admin.credential.cert({
+      projectId,
+      clientEmail,
+      privateKey: privateKey.replace(/\\n/g, '\n'), // 개행 문자 처리
+    }),
+    storageBucket,
   });
 }
 


### PR DESCRIPTION
## 📌 작업 개요
- 파이어베이스 연동을 위한 작업

## 🔗 관련 이슈
- #106 

## ✅ 작업 내용
- Firebase Admin SDK 초기화 방식을 환경 변수 기반으로 코드 작성
- `FIREBASE_PRIVATE_KEY`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PROJECT_ID`, `FIREBASE_STORAGE_BUCKET` 환경 변수를 사용하도록 코드작성

## 🧪 테스트 내용 
- 없음

## ⚠️ 특이사항
- 없음