### PR TITLE
fix: CONTRACT 오류 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,8 @@
         "passport-local": "^1.0.0",
         "reflect-metadata": "^0.2.2",
         "strip-bom-stream": "^5.0.0",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1",
         "tslib": "^2.8.1",
         "uuid": "^11.1.0"
       },
@@ -64,6 +66,50 @@
         "prisma": "^6.12.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -607,6 +653,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
@@ -1221,6 +1273,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -2688,6 +2746,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2865,6 +2929,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/compress-commons": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
@@ -2885,7 +2958,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -3240,7 +3312,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -3991,7 +4062,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4536,7 +4606,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -5193,7 +5262,6 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -6019,6 +6087,13 @@
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "license": "MIT"
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -6029,6 +6104,13 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
@@ -6060,6 +6142,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -6690,11 +6778,17 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -6884,7 +6978,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8311,6 +8404,81 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/swagger-ui-dist": {
       "version": "5.21.0",
       "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.21.0.tgz",
@@ -8318,6 +8486,21 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/synckit": {
@@ -9182,7 +9365,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/xtend": {
@@ -9209,6 +9391,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -9282,6 +9473,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/zip-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,6 @@
         "passport-local": "^1.0.0",
         "reflect-metadata": "^0.2.2",
         "strip-bom-stream": "^5.0.0",
-        "swagger-jsdoc": "^6.2.8",
-        "swagger-ui-express": "^5.0.1",
         "tslib": "^2.8.1",
         "uuid": "^11.1.0"
       },
@@ -66,50 +64,6 @@
         "prisma": "^6.12.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
-      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
-    "node_modules/@apidevtools/openapi-schemas": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
-      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@apidevtools/swagger-methods": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
-      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
-      "license": "MIT"
-    },
-    "node_modules/@apidevtools/swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
-      "license": "MIT",
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@apidevtools/openapi-schemas": "^2.0.4",
-        "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "z-schema": "^5.0.1"
-      },
-      "peerDependencies": {
-        "openapi-types": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -653,12 +607,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
-    },
-    "node_modules/@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-      "license": "MIT"
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
@@ -1273,12 +1221,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -2746,12 +2688,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/call-me-maybe": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
-      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
-      "license": "MIT"
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2929,15 +2865,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/compress-commons": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
@@ -2958,6 +2885,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -3312,6 +3240,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -4062,6 +3991,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4606,6 +4536,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -5262,6 +5193,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -6087,13 +6019,6 @@
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "license": "MIT"
     },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
-      "license": "MIT"
-    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -6104,13 +6029,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
@@ -6142,12 +6060,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.mergewith": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -6778,17 +6690,11 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
-    },
-    "node_modules/openapi-types": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
-      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -6978,6 +6884,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8404,81 +8311,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/swagger-jsdoc": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
-      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "6.2.0",
-        "doctrine": "3.0.0",
-        "glob": "7.1.6",
-        "lodash.mergewith": "^4.6.2",
-        "swagger-parser": "^10.0.3",
-        "yaml": "2.0.0-1"
-      },
-      "bin": {
-        "swagger-jsdoc": "bin/swagger-jsdoc.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/swagger-jsdoc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/swagger-jsdoc/node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/swagger-jsdoc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@apidevtools/swagger-parser": "10.0.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/swagger-ui-dist": {
       "version": "5.21.0",
       "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.21.0.tgz",
@@ -8486,21 +8318,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"
-      }
-    },
-    "node_modules/swagger-ui-express": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
-      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
-      "license": "MIT",
-      "dependencies": {
-        "swagger-ui-dist": ">=5.0.0"
-      },
-      "engines": {
-        "node": ">= v0.10.32"
-      },
-      "peerDependencies": {
-        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/synckit": {
@@ -9365,6 +9182,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/xtend": {
@@ -9391,15 +9209,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.0.0-1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
-      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -9473,36 +9282,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/z-schema": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
-      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "validator": "^13.7.0"
-      },
-      "bin": {
-        "z-schema": "bin/z-schema"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "commander": "^9.4.1"
-      }
-    },
-    "node_modules/z-schema/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/zip-stream": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "passport-local": "^1.0.0",
     "reflect-metadata": "^0.2.2",
     "strip-bom-stream": "^5.0.0",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1",
     "tslib": "^2.8.1",
     "uuid": "^11.1.0"
   },

--- a/src/common/utils/contract.converter.ts
+++ b/src/common/utils/contract.converter.ts
@@ -1,0 +1,88 @@
+import { Transform } from 'class-transformer';
+
+/** 내부 유틸리티: 식별자 정규화 */
+function normalizeIdentifier(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === '') return undefined;
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') return Number(value);
+  if (typeof value === 'object') {
+    const candidate = (value as any)?.id ?? (value as any)?.value;
+    return candidate === null || candidate === undefined || candidate === ''
+      ? undefined
+      : Number(candidate);
+  }
+  const numeric = Number(value as any);
+  return Number.isFinite(numeric) ? numeric : undefined;
+}
+
+/** 내부 유틸리티: 통화 금액 정규화 */
+function normalizeCurrencyAmount(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === '') return undefined;
+  if (typeof value === 'number') return value;
+  const numeric = Number(String(value).replace(/[^\d.-]/g, '')); // 예: "1,000,000원" → 1000000
+  return Number.isFinite(numeric) ? numeric : undefined;
+}
+
+/** 내부 유틸리티: 한국 표준시 기준의 날짜‧시간 문자열로 변환 */
+function toKoreaStandardTimeDateTimeString(value: unknown): string | undefined {
+  if (value === null || value === undefined || value === '') return undefined;
+
+  // Date 인스턴스인 경우
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    const isoWithoutZ = value.toISOString().replace('Z', '');
+    return `${isoWithoutZ}+09:00`;
+  }
+
+  if (typeof value !== 'string') return undefined;
+
+  let s = value.trim();
+  if (!s) return undefined;
+
+  // 1) 슬래시를 하이픈으로 통일
+  s = s.replace(/\//g, '-');
+
+  // 2) 'YYYY-MM-DD HH:mm' | 'YYYY-MM-DD HH:mm:ss' → 'YYYY-MM-DDTHH:mm(:ss)'
+  if (/^\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}(?::\d{2})?$/.test(s) && !s.includes('T')) {
+    s = s.replace(/\s+/, 'T');
+  }
+
+  // 3) 초가 없으면 추가
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(s)) {
+    s = `${s}:00`;
+  }
+
+  // 4) 시차 정보가 없으면 한국 표준시(+09:00) 부여
+  if (!/(?:[zZ]|[+-]\d{2}:\d{2})$/.test(s)) {
+    s = `${s}+09:00`;
+  }
+
+  // 간단 유효성 검사
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return undefined;
+  return s;
+}
+
+/** 식별자(숫자)로 변환 */
+export function ToIdentifier() {
+  return Transform(({ value }) => normalizeIdentifier(value), { toClassOnly: true });
+}
+
+/** 통화 금액(숫자)으로 변환 */
+export function ToCurrencyAmount() {
+  return Transform(({ value }) => normalizeCurrencyAmount(value), { toClassOnly: true });
+}
+
+/** 한국 표준시 기준 날짜‧시간 문자열로 변환 */
+export function ToKoreaStandardTimeDateTime() {
+  return Transform(
+    ({ value }) => {
+      if (Array.isArray(value)) {
+        return value
+          .map(toKoreaStandardTimeDateTimeString)
+          .filter((v): v is string => typeof v === 'string' && v.length > 0);
+      }
+      return toKoreaStandardTimeDateTimeString(value);
+    },
+    { toClassOnly: true },
+  );
+}

--- a/src/common/utils/validate.dto.ts
+++ b/src/common/utils/validate.dto.ts
@@ -22,14 +22,14 @@ function validateDto<T extends object>(DtoClass: new () => T) {
       whitelist: true, // DTO에 정의되지 않은 속성 제거
       forbidNonWhitelisted: false, // 정의되지 않은 속성이 있어도 에러 발생하지 않음
       skipMissingProperties: false, // 필수 속성 검사
+      stopAtFirstError: false,
     });
 
     if (errors.length > 0) {
       const messages = errors.map((err) => {
-        const constraints = err.constraints || {};
         return {
           property: err.property,
-          errors: Object.values(constraints),
+          errors: Object.values(err.constraints ?? {}),
         };
       });
 

--- a/src/contracts/contract.mapper.ts
+++ b/src/contracts/contract.mapper.ts
@@ -23,7 +23,6 @@ export type ContractResponse = {
     | 'contractDraft'
     | 'contractSuccessful'
     | 'contractFailed';
-  // 👇 optional 로 두면 프론트 미사용 시에도 안전
   contractDocuments: { id: number; fileName: string }[];
 };
 
@@ -109,13 +108,14 @@ function mapMeeting(m: RawMeeting): { date: string; alarms: string[] } {
  * - undefined 반환한 키는 JSON 직렬화 시 빠짐
  */
 export function mapContract(row: RawContract): ContractResponse {
+  const price = row.contractPrice == null ? 0 : decimalToNumber(row.contractPrice);
   const response: ContractResponse = {
     id: row.id,
     car: row.car ? { id: row.car.id, model: row.car.model } : undefined,
     customer: row.customer ? { id: row.customer.id, name: row.customer.name } : undefined,
     user: row.user ? { id: row.user.id, name: row.user.name } : undefined,
     meetings: (row.meetings ?? []).map(mapMeeting),
-    contractPrice: decimalToNumber(row.contractPrice),
+    contractPrice: price,
     resolutionDate: toLocalDateTime(row.resolutionDate ?? null),
     status: toCamelStatus(String(row.status)),
     contractDocuments: (row.contractDocuments ?? []).map((d: { id: number; fileName: string }) => ({

--- a/src/contracts/contract.mapper.ts
+++ b/src/contracts/contract.mapper.ts
@@ -14,16 +14,17 @@ export type ContractResponse = {
   car?: { id: number; model: string };
   customer?: { id: number; name: string };
   user?: { id: number; name: string };
-  meetings: Array<{ date: string; alarms: string[] }>;
-  contractPrice?: number; // 없으면 필드 자체 제외
-  resolutionDate: string | null; // 없으면 null
+  meetings: { date: string; alarms: string[] }[];
+  contractPrice?: number;
+  resolutionDate: string | null;
   status:
     | 'carInspection'
     | 'priceNegotiation'
     | 'contractDraft'
     | 'contractSuccessful'
-    | 'contractFailed'
-    | string;
+    | 'contractFailed';
+  // 👇 optional 로 두면 프론트 미사용 시에도 안전
+  contractDocuments: { id: number; fileName: string }[];
 };
 
 /* ---------- Raw 타입 (Prisma Include 결과 최소 정의) ---------- */
@@ -43,6 +44,7 @@ export type RawContract = {
   contractPrice?: number | Prisma.Decimal | null;
   resolutionDate?: Date | string | null;
   status: PrismaContractStatus | string;
+  contractDocuments?: { id: number; fileName: string }[] | null;
 };
 
 /* ---------- utils ---------- */
@@ -86,8 +88,9 @@ const STATUS_KEY: Record<string, ContractResponse['status']> = {
   CONTRACT_SUCCESSFUL: 'contractSuccessful',
   CONTRACT_FAILED: 'contractFailed',
 };
+
 export function toCamelStatus(s: string): ContractResponse['status'] {
-  return STATUS_KEY[s] ?? s;
+  return (STATUS_KEY[s] ?? s) as ContractResponse['status'];
 }
 
 /* ---------- mappers ---------- */
@@ -115,6 +118,10 @@ export function mapContract(row: RawContract): ContractResponse {
     contractPrice: decimalToNumber(row.contractPrice),
     resolutionDate: toLocalDateTime(row.resolutionDate ?? null),
     status: toCamelStatus(String(row.status)),
+    contractDocuments: (row.contractDocuments ?? []).map((d: { id: number; fileName: string }) => ({
+      id: d.id,
+      fileName: d.fileName,
+    })),
   };
 
   return response; // 순서 유지

--- a/src/contracts/controller.ts
+++ b/src/contracts/controller.ts
@@ -35,7 +35,9 @@ export default class ContractController {
       const pageNum = page ? Number(page) : undefined;
       const sizeNum = pageSize ? Number(pageSize) : undefined;
 
-      if (grouped === 'true') {
+      const wantsGrouped = grouped === 'true' || (!pageNum && !sizeNum);
+
+      if (wantsGrouped) {
         const result = await this.contractService.getContractsGroupedPage(user, {
           searchBy,
           keyword,
@@ -49,12 +51,12 @@ export default class ContractController {
       const result = await this.contractService.getContractsPage(user, {
         searchBy,
         keyword,
-        page: pageNum,
-        pageSize: sizeNum,
+        page: pageNum!,
+        pageSize: sizeNum!,
       });
       res.status(200).json(result);
     } catch (error) {
-      next(error);
+      next(error as Error);
     }
   };
 
@@ -111,11 +113,10 @@ export default class ContractController {
     try {
       const user = req.user as RequestUser;
       const contractId = Number(req.params.contractId);
-
       await this.contractService.deleteContract(user, contractId);
-      res.status(204).send();
-    } catch (error) {
-      next(error);
+      res.status(200).json({ message: 'OK' });
+    } catch (e) {
+      next(e as Error);
     }
   };
 
@@ -124,9 +125,9 @@ export default class ContractController {
     try {
       const user = req.user as RequestUser;
       const rows = await this.contractService.getContractCars(user);
-      res.status(200).json(rows);
-    } catch (error) {
-      next(error);
+      res.status(200).json(rows.map((r) => ({ id: r.id, data: r.model })));
+    } catch (e) {
+      next(e as Error);
     }
   };
 
@@ -134,10 +135,10 @@ export default class ContractController {
   getContractCustomers = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
       const user = req.user as RequestUser;
-      const rows = await this.contractService.getContractCustomers(user);
-      res.status(200).json(rows);
-    } catch (error) {
-      next(error);
+      const rows = await this.contractService.getContractCustomers(user); // { id, name }
+      res.status(200).json(rows.map((r) => ({ id: r.id, data: r.name })));
+    } catch (e) {
+      next(e as Error);
     }
   };
 
@@ -145,10 +146,10 @@ export default class ContractController {
   getContractUsers = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
       const user = req.user as RequestUser;
-      const rows = await this.contractService.getContractUsers(user);
-      res.status(200).json(rows);
-    } catch (error) {
-      next(error);
+      const rows = await this.contractService.getContractUsers(user); // { id, name, email }
+      res.status(200).json(rows.map((r) => ({ id: r.id, data: r.name })));
+    } catch (e) {
+      next(e as Error);
     }
   };
 }

--- a/src/contracts/dto/create-contract.dto.ts
+++ b/src/contracts/dto/create-contract.dto.ts
@@ -9,18 +9,26 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ContractStatus, Possession } from '@prisma/client';
+import { ToIdentifier, ToCurrencyAmount } from '../../common/utils/contract.converter';
 import { MeetingDto } from './meeting.dto';
 
 export class CreateContractDto {
+  @IsOptional()
   @IsInt()
+  @ToIdentifier()
+  userId?: number;
+
+  @IsInt()
+  @ToIdentifier()
   carId: number;
 
   @IsInt()
+  @ToIdentifier()
   customerId: number;
 
   @IsOptional()
-  @Type(() => Number)
   @IsNumber()
+  @ToCurrencyAmount()
   contractPrice?: number;
 
   @IsOptional()

--- a/src/contracts/dto/meeting.dto.ts
+++ b/src/contracts/dto/meeting.dto.ts
@@ -1,11 +1,13 @@
-import { IsArray, IsDateString, IsOptional } from 'class-validator';
+import { IsArray, IsOptional, IsString } from 'class-validator';
+import { ToKoreaStandardTimeDateTime } from '../../common/utils/contract.converter';
 
 export class MeetingDto {
-  @IsDateString()
+  @IsString()
+  @ToKoreaStandardTimeDateTime()
   date!: string;
 
-  @IsOptional()
   @IsArray()
-  @IsDateString({}, { each: true })
+  @IsOptional()
+  @ToKoreaStandardTimeDateTime()
   alarms?: string[];
 }

--- a/src/contracts/dto/update-contract.dto.ts
+++ b/src/contracts/dto/update-contract.dto.ts
@@ -1,8 +1,17 @@
-import { IsOptional, IsEnum, IsInt, IsDateString, ValidateNested } from 'class-validator';
+import {
+  IsOptional,
+  IsEnum,
+  IsInt,
+  IsDateString,
+  ValidateNested,
+  IsArray,
+  IsNumber,
+} from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { ContractStatus as PrismaContractStatus } from '@prisma/client';
 import { UpdateContractDocumentDto } from './update-contract-document.dto';
-import { UpdateMeetingDto } from './update-meeting.dto';
+import { MeetingDto } from './meeting.dto';
+import { ToIdentifier, ToCurrencyAmount } from '../../common/utils/contract.converter';
 
 function toPrismaStatus(value?: unknown): PrismaContractStatus | undefined {
   if (value == null) return undefined;
@@ -28,6 +37,21 @@ function toPrismaStatus(value?: unknown): PrismaContractStatus | undefined {
 
 export class UpdateContractDto {
   @IsOptional()
+  @IsInt()
+  @ToIdentifier()
+  userId?: number;
+
+  @IsOptional()
+  @IsInt()
+  @ToIdentifier()
+  customerId?: number;
+
+  @IsOptional()
+  @IsInt()
+  @ToIdentifier()
+  carId?: number;
+
+  @IsOptional()
   @Transform(({ value }) => toPrismaStatus(value))
   @IsEnum(PrismaContractStatus)
   status?: PrismaContractStatus;
@@ -37,20 +61,18 @@ export class UpdateContractDto {
   resolutionDate?: string;
 
   @IsOptional()
-  @IsInt()
+  @IsNumber()
+  @ToCurrencyAmount()
   contractPrice?: number;
 
   @IsOptional()
+  @IsArray()
   @ValidateNested({ each: true })
-  @Type(() => UpdateMeetingDto)
-  meetings?: UpdateMeetingDto[];
+  @Type(() => MeetingDto)
+  meetings?: MeetingDto[];
 
   @IsOptional()
   @ValidateNested({ each: true })
   @Type(() => UpdateContractDocumentDto)
   contractDocuments?: UpdateContractDocumentDto[];
-
-  @IsOptional() @IsInt() userId?: number;
-  @IsOptional() @IsInt() customerId?: number;
-  @IsOptional() @IsInt() carId?: number;
 }

--- a/src/contracts/dto/update-meeting.dto.ts
+++ b/src/contracts/dto/update-meeting.dto.ts
@@ -1,11 +1,14 @@
-import { IsArray, IsDateString, IsOptional } from 'class-validator';
+import { IsArray, IsOptional, IsString } from 'class-validator';
+import { ToKoreaStandardTimeDateTime } from '../../common/utils/contract.converter';
 
 export class UpdateMeetingDto {
-  @IsDateString()
-  date!: string;
-
   @IsOptional()
+  @IsString()
+  @ToKoreaStandardTimeDateTime()
+  date?: string;
+
   @IsArray()
-  @IsDateString({}, { each: true })
+  @IsOptional()
+  @ToKoreaStandardTimeDateTime()
   alarms?: string[];
 }


### PR DESCRIPTION
## 📌 작업 개요

* 프론트 수정 불가 조건에 맞춰 **입력 정규화(컨버터) + 검증 + 저장소/맵퍼 보정**을 적용
* 같은 경로(`/contracts`)에서 **그룹형/페이지형 목록 분기**, 드롭다운/삭제 응답 **프론트 스펙**에 맞춤

## 🔗 관련 이슈

* #124 

## ✅ 작업 내용

* **컨버터 신규 추가:** `src/contracts/contract.converter.ts`

  * `ToIdentifier`(식별자 정수 변환), `ToCurrencyAmount`(통화 금액 숫자 변환), `ToKoreaStandardTimeDateTime`(`YYYY/MM/DD HH:mm` → ISO+09:00)
  * ESLint 규칙 준수(템플릿 리터럴, 불필요 이스케이프 제거)

  * `create-contract.dto.ts`, `update-contract.dto.ts`에 `@ToIdentifier`, `@ToCurrencyAmount` 적용
  * `meeting.dto.ts`, `update-meeting.dto.ts`에 `@ToKoreaStandardTimeDateTime` 적용
  * `@Type(() => MeetingDto)`로 중첩 배열 변환 활성화
  * 금액/담당자 ID는 **옵셔널 허용**(프론트 미전달 대비)
* **검증 미들웨어 유지 보완:** `validate-dto.ts`

  * `plainToInstance` 기반 변환 결과를 `req.body`에 반영(기존 로직 유지)
  * 검증 옵션 정리(`stopAtFirstError: false`)
* **컨트롤러(요약):**

  * `GET /contracts` 한 경로에서 **page/pageSize 없으면 그룹형**, 있으면 페이지형을 반환
  * 드롭다운(`/contracts/cars|customers|users`) → `{ id, data }[]`로 매핑
  * 생성 시 `userId`/`contractPrice` 기본값 보정(미전달 대비)
* **레포지토리 보강:** `repository.ts`

  * 계약 **등록/수정** 시 미팅 생성부 안전화

    * `date` 값이 **있는 항목만** 생성(타입 가드)
    * `alarms`는 문자열만 수용해 `Date`로 변환
    * 헬퍼 `isNonEmptyText`, `toDateStrict` 추가
  * 문서 ID 처리 시 정수만 수용하도록 필터링 강화
* **응답 맵퍼 보정:** `contract.mapper.ts`

  * `contractPrice`를 **항상 number**로 보장(없으면 0) → 프론트의 `toLocaleString()` 안전

---

## 🧪 테스트 내용

* \[POST] `/contracts`

  * 폼에서 날짜 `YYYY/MM/DD HH:mm`, 금액 `"1,000,000"` 형태로 전송 → **201 + JSON** 응답, `contractPrice`는 number
 
<img width="925" height="730" alt="계약보드_등록" src="https://github.com/user-attachments/assets/6cff8a05-9bc4-47b3-9d30-29987f616b42" />

* \[GET] `/contracts`

  * 쿼리 없음 → **상태별 그룹 객체**(프론트 타입 일치)
  * `?page=1&pageSize=10` → **페이지형**(OffsetPagination) 정상
  
* \[GET] `/contracts/cars|customers|users` → `{ id, data }[]` 구조 확인
<img width="1624" height="749" alt="계약보드" src="https://github.com/user-attachments/assets/39d3d95d-2b9c-49e3-8708-7e6486c3ca71" />
<img width="1883" height="785" alt="계약보드_Kcar" src="https://github.com/user-attachments/assets/9b6a22f1-b977-4503-899a-dbe4451c7401" />
<img width="1878" height="796" alt="계약보드_햇살카 직원1" src="https://github.com/user-attachments/assets/006ede6c-6342-4a3d-ae13-06096e508356" />
  
* \[DELETE] `/contracts/:id` → `200 { message: 'OK' }`
<img width="933" height="715" alt="계약보드_삭제" src="https://github.com/user-attachments/assets/dfbaf122-f5af-4bdc-be99-204038fe7007" />


## ⚠️ 특이사항

* 컨버터 동작을 위해 프로젝트에 **`reflect-metadata` import** 및 `tsconfig`의 `experimentalDecorators`, `emitDecoratorMetadata`가 필요합니다(현 설정 유지 가정).
* 기존에 `@IsDateString`을 쓰던 필드는 문자열+컨버터 조합으로 변경되어 **프론트 포맷을 그대로 수용**합니다.
* 레포지토리에서 업데이트 시 미팅을 **전체 교체(deleteMany + create)** 하므로, 부분 수정이 필요하다면 후속 이슈로 분리 예정.
* contract.update 수정 중입니다! 우선 프론트 테스트를 위해 PR 올립니다.
