### PR TITLE
Fix: [#125] 계약서 수정 API를 계약 수정 API를 활용하도록 수정

### DIFF
--- a/src/contract-documents/contract-documents.routes.ts
+++ b/src/contract-documents/contract-documents.routes.ts
@@ -9,7 +9,6 @@ import ContractDocumentsRepository from './repository';
 import GetContractDocumentsDto from './dto/get-contract-documents.dto';
 import UploadContractDocumentDto from './dto/upload-contract-document.dto';
 import DownloadContractDocumentsDto from './dto/download-contract-documents.dto';
-import EditContractDocumentsDto from './dto/edit-contract-documents.dto';
 
 const createContractDocumentsRouter = (prisma: PrismaClient) => {
   const router = Router();
@@ -282,87 +281,6 @@ const createContractDocumentsRouter = (prisma: PrismaClient) => {
     isAuthenticated,
     validateDto(DownloadContractDocumentsDto),
     contractDocumentsController.downloadMultipleDocuments,
-  );
-
-  /**
-   * @swagger
-   * /contractDocuments/{contractId}:
-   *   patch:
-   *     tags:
-   *       - ContractDocuments
-   *     summary: 계약서 수정
-   *     description: 계약서 추가/삭제
-   *     security:
-   *       - bearerAuth: []
-   *     parameters:
-   *       - in: path
-   *         name: contractId
-   *         required: true
-   *         schema:
-   *           type: integer
-   *         description: 수정할 계약 ID
-   *     requestBody:
-   *       required: true
-   *       content:
-   *         multipart/form-data:
-   *           schema:
-   *             type: object
-   *             properties:
-   *               deleteDocumentIds:
-   *                 type: array
-   *                 items:
-   *                   type: integer
-   *                 description: 삭제할 문서 ID 목록
-   *                 example: [1, 2]
-   *               files:
-   *                 type: array
-   *                 items:
-   *                   type: string
-   *                   format: binary
-   *                 maxItems: 10
-   *                 description: 추가할 파일들 (최대 10개)
-   *     responses:
-   *       200:
-   *         description: 계약서 수정 성공
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: object
-   *               properties:
-   *                 message:
-   *                   type: string
-   *                   example: "계약서 수정 성공"
-   *       400:
-   *         description: 잘못된 요청
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: object
-   *               properties:
-   *                 message:
-   *                   type: string
-   *                   example: "잘못된 요청입니다"
-   *       401:
-   *         description: 인증이 필요합니다
-   *       404:
-   *         description: 계약을 찾을 수 없습니다
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: object
-   *               properties:
-   *                 message:
-   *                   type: string
-   *                   example: "계약을 찾을 수 없습니다"
-   */
-
-  // 계약서 수정 (추가/삭제)
-  router.patch(
-    '/:contractId',
-    isAuthenticated,
-    upload.array('files', 10),
-    validateDto(EditContractDocumentsDto),
-    contractDocumentsController.editContractDocuments,
   );
 
   return router;

--- a/src/contract-documents/contract-documents.routes.ts
+++ b/src/contract-documents/contract-documents.routes.ts
@@ -162,7 +162,66 @@ const createContractDocumentsRouter = (prisma: PrismaClient) => {
    *       401:
    *         description: 인증이 필요합니다
    */
+  // 계약서 추가용 계약 목록 조회
+  router.get('/draft', isAuthenticated, contractDocumentsController.getContractsForDraft);
 
+  /**
+   * @swagger
+   * /contractDocuments/upload:
+   *   post:
+   *     tags:
+   *       - ContractDocuments
+   *     summary: 계약서 업로드
+   *     description: 계약서 파일 업로드 (최대 10개, 각 파일 최대 10MB)
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         multipart/form-data:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - contractId
+   *               - files
+   *             properties:
+   *               contractId:
+   *                 type: integer
+   *                 description: 계약 ID
+   *                 example: 1
+   *               files:
+   *                 type: array
+   *                 items:
+   *                   type: string
+   *                   format: binary
+   *                 maxItems: 10
+   *                 description: 업로드할 파일들 (최대 10개, 각 10MB)
+   *     responses:
+   *       200:
+   *         description: 계약서 업로드 성공
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 message:
+   *                   type: string
+   *                   example: "계약서 업로드 성공"
+   *                 contractDocumentId:
+   *                   type: integer
+   *       400:
+   *         description: 잘못된 요청
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 message:
+   *                   type: string
+   *                   example: "파일이 없습니다"
+   *       401:
+   *         description: 인증이 필요합니다
+   */
   // 계약서 업로드
   router.post(
     '/upload',

--- a/src/contract-documents/controller.ts
+++ b/src/contract-documents/controller.ts
@@ -3,7 +3,6 @@ import ContractDocumentsService from './service';
 import GetContractDocumentsDto from './dto/get-contract-documents.dto';
 import UploadContractDocumentDto from './dto/upload-contract-document.dto';
 import DownloadContractDocumentsDto from './dto/download-contract-documents.dto';
-import EditContractDocumentsDto from './dto/edit-contract-documents.dto';
 
 // Express의 기본 Request 타입 사용 (index.d.ts에서 확장된 타입)
 export default class ContractDocumentsController {
@@ -102,28 +101,48 @@ export default class ContractDocumentsController {
     }
   };
 
-  editContractDocuments = async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
-    try {
-      const { companyId, id: userId } = req.user!;
-      const { contractId } = req.params;
-      const { deleteDocumentIds } = req.body as EditContractDocumentsDto;
-      const files = req.files as Express.Multer.File[] | undefined;
+  // ❌ editContractDocuments 메서드 제거됨 - 이제 계약 API에서 처리
 
-      await this.contractDocumentsService.editContractDocuments(
-        companyId,
-        userId,
-        parseInt(contractId || '0', 10),
-        deleteDocumentIds,
-        files,
-      );
+  // ✨ 새로운 메서드들: 계약 API에서 내부적으로 호출할 헬퍼 메서드들
+  // 이 메서드들은 HTTP 엔드포인트가 아니라 다른 서비스에서 직접 호출하는 메서드들입니다.
 
-      res.status(200).json({ message: '계약서 수정 성공' });
-    } catch (error) {
-      next(error);
-    }
-  };
+  /**
+   * 계약서를 계약에 연결 (계약 API 내부에서 호출)
+   */
+  async attachDocumentsToContract(
+    companyId: number,
+    contractId: number,
+    documentIds: number[],
+  ): Promise<void> {
+    return this.contractDocumentsService.attachDocumentsToContract(
+      companyId,
+      contractId,
+      documentIds,
+    );
+  }
+
+  /**
+   * 계약서 파일명 업데이트 (계약 API 내부에서 호출)
+   */
+  async updateContractDocumentFileNames(
+    companyId: number,
+    contractId: number,
+    updates: { id: number; fileName?: string }[],
+  ): Promise<void> {
+    return this.contractDocumentsService.updateContractDocumentFileNames(
+      companyId,
+      contractId,
+      updates,
+    );
+  }
+
+  /**
+   * 특정 계약의 계약서 목록 조회 (계약 API 내부에서 호출)
+   */
+  async getContractDocumentsByContractId(
+    companyId: number,
+    contractId: number,
+  ): Promise<{ id: number; fileName: string }[]> {
+    return this.contractDocumentsService.getContractDocumentsByContractId(companyId, contractId);
+  }
 }

--- a/src/contract-documents/controller.ts
+++ b/src/contract-documents/controller.ts
@@ -23,6 +23,19 @@ export default class ContractDocumentsController {
     }
   };
 
+  // ✨ 새로운 메서드: 계약서 추가용 계약 목록 조회
+  getContractsForDraft = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const { companyId } = req.user!;
+
+      const result = await this.contractDocumentsService.getContractsForDraft(companyId);
+
+      res.status(200).json(result);
+    } catch (error) {
+      next(error);
+    }
+  };
+
   uploadContractDocuments = async (
     req: Request,
     res: Response,

--- a/src/contract-documents/repository.ts
+++ b/src/contract-documents/repository.ts
@@ -213,4 +213,57 @@ export default class ContractDocumentsRepository {
       },
     });
   }
+  // ✨ 새로운 메서드들: 계약 API 통합용
+
+  /**
+   * 계약서들을 특정 계약에 연결
+   */
+  async attachDocumentsToContract(contractId: number, documentIds: number[]): Promise<void> {
+    await this.prisma.contractDocument.updateMany({
+      where: {
+        id: {
+          in: documentIds,
+        },
+      },
+      data: {
+        contractId,
+      },
+    });
+  }
+
+  /**
+   * 계약서 파일명 업데이트
+   */
+  async updateDocumentFileName(documentId: number, fileName: string): Promise<void> {
+    await this.prisma.contractDocument.update({
+      where: {
+        id: documentId,
+      },
+      data: {
+        fileName,
+      },
+    });
+  }
+
+  /**
+   * 특정 계약에 속한 계약서들 조회
+   */
+  async findDocumentsByContractId(
+    contractId: number,
+    companyId: number,
+  ): Promise<ContractDocument[]> {
+    return this.prisma.contractDocument.findMany({
+      where: {
+        contractId,
+        deletedAt: null,
+        contract: {
+          companyId,
+          deletedAt: null,
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+  }
 }

--- a/src/contract-documents/repository.ts
+++ b/src/contract-documents/repository.ts
@@ -12,6 +12,17 @@ interface ContractWithCustomer {
   } | null;
 }
 
+interface ContractForDraft {
+  id: number;
+  car: {
+    carNumber: string;
+    model: string; // Car 스키마의 model 필드 사용
+  };
+  customer: {
+    name: string;
+  } | null;
+}
+
 export default class ContractDocumentsRepository {
   // eslint-disable-next-line no-empty-function
   constructor(private readonly prisma: PrismaClient) {}
@@ -110,6 +121,38 @@ export default class ContractDocumentsRepository {
     ]);
 
     return { documents, total };
+  }
+
+  // ✨ 새로운 메서드: 계약서 추가용 계약 목록 조회
+  async findContractsForDraft(companyId: number): Promise<ContractForDraft[]> {
+    return this.prisma.contract.findMany({
+      where: {
+        companyId,
+        deletedAt: null,
+        // 계약서가 없는 계약들만 조회
+        contractDocuments: {
+          none: {
+            deletedAt: null,
+          },
+        },
+      },
+      include: {
+        car: {
+          select: {
+            carNumber: true,
+            model: true, // Car 스키마의 model 필드 사용
+          },
+        },
+        customer: {
+          select: {
+            name: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
   }
 
   async findContractById(

--- a/src/contract-documents/service.ts
+++ b/src/contract-documents/service.ts
@@ -49,6 +49,12 @@ interface PaginatedResult {
   data: ContractDocumentListItem[];
 }
 
+// ✨ 새로운 인터페이스: 계약서 추가용 계약 목록
+interface ContractForDraftItem {
+  id: number;
+  data: string;
+}
+
 export default class ContractDocumentsService {
   private readonly emailService: EmailService;
   private readonly allowedExtensions = ['.pdf', '.doc', '.docx', '.jpg', '.jpeg', '.png'];
@@ -83,6 +89,16 @@ export default class ContractDocumentsService {
       totalItemCount: total,
       data,
     };
+  }
+
+  // ✨ 새로운 메서드: 계약서 추가용 계약 목록 조회
+  async getContractsForDraft(companyId: number): Promise<ContractForDraftItem[]> {
+    const contracts = await this.contractDocumentsRepository.findContractsForDraft(companyId);
+
+    return contracts.map((contract) => ({
+      id: contract.id,
+      data: `${contract.car.model} - ${contract.customer?.name || '고객정보없음'}`,
+    }));
   }
 
   async uploadContractDocuments(

--- a/src/contracts/contracts.routes.ts
+++ b/src/contracts/contracts.routes.ts
@@ -76,150 +76,153 @@ const ContractsRouter = (prisma: PrismaClient): Router => {
    *         description: 상태별 그룹화 여부
    *     responses:
    *       '200':
-   *          * content:
-   * application/json:
-   * schema:
-   * type: object
-   * properties:
-   * totalCount:
-   * type: integer
-   * description: 전체 검색 결과 수
-   * data:
-   * type: array
-   * items:
-   * type: object
-   * properties:
-   * id:
-   * type: string
-   * description: 계약 ID
-   * car:
-   * type: object
-   * properties:
-   * id:
-   * type: integer
-   * name:
-   * type: string
-   * model:
-   * type: string
-   * example:
-   * id: 1
-   * name: "아반떼"
-   * model: "KS"
-   * customer:
-   * type: object
-   * properties:
-   * id:
-   * type: integer
-   * name:
-   * type: string
-   * example:
-   * id: "1"
-   * name: "김철수"
-   * user:
-   * type: object
-   * properties:
-   * id:
-   * type: integer
-   * name:
-   * type: string
-   * example:
-   * id: "1"
-   * name: "김민재"
-   * contract:
-   * type: object
-   * properties:
-   * date:
-   * type: object
-   * properties:
-   * from:
-   * type: string
-   * format: date-time
-   * description: 계약 시작일
-   * to:
-   * type: string
-   * format: date-time
-   * description: 계약 종료일
-   * contractPrice:
-   * type: integer
-   * description: 계약 가격
-   * status:
-   * type: string
-   * description: 계약 상태
-   * example:
-   * date:
-   * from: "2024-02-21T09:00:00.000Z"
-   * to: "2024-02-21T09:00:00.000Z"
-   * contractPrice: 2000000
-   * status: "string"
-   * priceNegotiation:
-   * type: array
-   * items:
-   * type: object
-   * properties:
-   * price:
-   * type: integer
-   * date:
-   * type: string
-   * format: date-time
-   * example:
-   * price: 1800000
-   * date: "2024-02-21T07:49:09.000Z"
+   *         description: 계약 목록 조회 성공
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 totalCount:
+   *                   type: integer
+   *                   description: 전체 검색 결과 수
+   *                 data:
+   *                   type: array
+   *                   items:
+   *                     type: object
+   *                     properties:
+   *                       id:
+   *                         type: string
+   *                         description: 계약 ID
+   *                       car:
+   *                         type: object
+   *                         properties:
+   *                           id:
+   *                             type: integer
+   *                           name:
+   *                             type: string
+   *                           model:
+   *                             type: string
+   *                         example:
+   *                           id: 1
+   *                           name: "아반떼"
+   *                           model: "KS"
+   *                       customer:
+   *                         type: object
+   *                         properties:
+   *                           id:
+   *                             type: integer
+   *                           name:
+   *                             type: string
+   *                         example:
+   *                           id: 1
+   *                           name: "김철수"
+   *                       user:
+   *                         type: object
+   *                         properties:
+   *                           id:
+   *                             type: integer
+   *                           name:
+   *                             type: string
+   *                         example:
+   *                           id: 1
+   *                           name: "김민재"
+   *                       contract:
+   *                         type: object
+   *                         properties:
+   *                           date:
+   *                             type: object
+   *                             properties:
+   *                               from:
+   *                                 type: string
+   *                                 format: date-time
+   *                                 description: 계약 시작일
+   *                               to:
+   *                                 type: string
+   *                                 format: date-time
+   *                                 description: 계약 종료일
+   *                           contractPrice:
+   *                             type: integer
+   *                             description: 계약 가격
+   *                           status:
+   *                             type: string
+   *                             description: 계약 상태
+   *                         example:
+   *                           date:
+   *                             from: "2024-02-21T09:00:00.000Z"
+   *                             to: "2024-02-21T09:00:00.000Z"
+   *                           contractPrice: 2000000
+   *                           status: "string"
+   *                       priceNegotiation:
+   *                         type: array
+   *                         items:
+   *                           type: object
+   *                           properties:
+   *                             price:
+   *                               type: integer
+   *                             date:
+   *                               type: string
+   *                               format: date-time
+   *                         example:
+   *                           - price: 1800000
+   *                             date: "2024-02-21T07:49:09.000Z"
+   *       '401':
+   *         $ref: '#/components/responses/Unauthorized'
    */
   contractRouter.get('/', controller.getContracts);
   /**
    * @swagger
    * /contracts/{contractId}:
-   * patch:
-   * tags:
-   * - Contracts
-   * summary: 계약 정보 수정
-   * description: 계약 정보 수정
-   * parameters:
-   * - in: path
-   * name: contractId
-   * required: true
-   * schema:
-   * type: integer
-   * requestBody:
-   * required: true
-   * content:
-   * application/json:
-   * schema:
-   * $ref: '#/components/schemas/UpdateContractRequest'
-   * responses:
-   * '200':
-   * description: 계약 정보 수정 성공
-   * content:
-   * application/json:
-   * schema:
-   * $ref: '#/components/schemas/ContractResponse'
-   * example:
-   * id: 123
-   * status: "contract_complete"
-   * resolutionDate:
-   * from: "2024-02-22T09:00:00.000Z"
-   * to: "2024-02-23T09:00:00.000Z"
-   * attachments:
-   * - id: 1
-   * fileName: "contract file 1"
-   * - id: 2
-   * fileName: "contract file 2"
-   * car:
-   * id: 1
-   * name: "아반떼"
-   * model: "KS"
-   * customer:
-   * id: 2
-   * name: "김철수"
-   * user:
-   * id: 3
-   * name: "김민재"
-   * '400':
-   * $ref: '#/components/responses/BadRequest'
-   * '401':
-   * $ref: '#/components/responses/Unauthorized'
-   * '404':
-   * $ref: '#/components/responses/NotFound'
+   *   patch:
+   *     tags:
+   *       - Contracts
+   *     summary: 계약 정보 수정
+   *     description: 계약 정보 수정
+   *     parameters:
+   *       - in: path
+   *         name: contractId
+   *         required: true
+   *         schema:
+   *           type: integer
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/components/schemas/UpdateContractRequest'
+   *     responses:
+   *       '200':
+   *         description: 계약 정보 수정 성공
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ContractResponse'
+   *             example:
+   *               id: 123
+   *               status: "contract_complete"
+   *               resolutionDate:
+   *                 from: "2024-02-22T09:00:00.000Z"
+   *                 to: "2024-02-23T09:00:00.000Z"
+   *               attachments:
+   *                 - id: 1
+   *                   fileName: "contract file 1"
+   *                 - id: 2
+   *                   fileName: "contract file 2"
+   *               car:
+   *                 id: 1
+   *                 name: "아반떼"
+   *                 model: "KS"
+   *               customer:
+   *                 id: 2
+   *                 name: "김철수"
+   *               user:
+   *                 id: 3
+   *                 name: "김민재"
+   *       '400':
+   *         $ref: '#/components/responses/BadRequest'
+   *       '401':
+   *         $ref: '#/components/responses/Unauthorized'
+   *       '404':
+   *         $ref: '#/components/responses/NotFound'
    */
   contractRouter.patch('/:contractId', validateDto(UpdateContractDto), controller.updateContract);
   /**
@@ -249,85 +252,85 @@ const ContractsRouter = (prisma: PrismaClient): Router => {
   /**
    * @swagger
    * /contracts/cars:
-   * get:
-   * tags:
-   * - Contracts
-   * summary: 계약용 차량 선택 목록 조회
-   * description: 계약 등록/수정 시 사용할 차량 목록 조회
-   * responses:
-   * '200':
-   * description: 차량 목록 조회 성공
-   * content:
-   * application/json:
-   * schema:
-   * type: array
-   * items:
-   * $ref: '#/components/schemas/ContractCarOption'
-   * example:
-   * - id: 1
-   * data: "그랜저 (111가 1111)"
-   * - id: 2
-   * data: "소나타 (222나 2222)"
-   * - id: 3
-   * data: "아반떼 (333다 3333)"
-   * '401':
-   * $ref: '#/components/responses/Unauthorized'
+   *   get:
+   *     tags:
+   *       - Contracts
+   *     summary: 계약용 차량 선택 목록 조회
+   *     description: 계약 등록/수정 시 사용할 차량 목록 조회
+   *     responses:
+   *       '200':
+   *         description: 차량 목록 조회 성공
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 $ref: '#/components/schemas/ContractCarOption'
+   *             example:
+   *               - id: 1
+   *                 data: "그랜저 (111가 1111)"
+   *               - id: 2
+   *                 data: "소나타 (222나 2222)"
+   *               - id: 3
+   *                 data: "아반떼 (333다 3333)"
+   *       '401':
+   *         $ref: '#/components/responses/Unauthorized'
    */
   contractRouter.get('/cars', controller.getContractCars);
   /**
    * @swagger
    * /contracts/customers:
-   * get:
-   * tags:
-   * - Contracts
-   * summary: 계약용 고객 선택 목록 조회
-   * description: 계약 등록/수정 시 사용할 고객 목록 조회
-   * responses:
-   * '200':
-   * description: 고객 목록 조회 성공
-   * content:
-   * application/json:
-   * schema:
-   * type: array
-   * items:
-   * $ref: '#/components/schemas/ContractCustomerOption'
-   * example:
-   * - id: 1
-   * data: "김철수(chulsu@codeit.com)"
-   * - id: 2
-   * data: "박영희(younghee@codeit.com)"
-   * - id: 3
-   * data: "이민지(minji@codeit.com)"
-   * '401':
-   * $ref: '#/components/responses/Unauthorized'
+   *   get:
+   *     tags:
+   *       - Contracts
+   *     summary: 계약용 고객 선택 목록 조회
+   *     description: 계약 등록/수정 시 사용할 고객 목록 조회
+   *     responses:
+   *       '200':
+   *         description: 고객 목록 조회 성공
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 $ref: '#/components/schemas/ContractCustomerOption'
+   *             example:
+   *               - id: 1
+   *                 data: "김철수(chulsu@codeit.com)"
+   *               - id: 2
+   *                 data: "박영희(younghee@codeit.com)"
+   *               - id: 3
+   *                 data: "이민지(minji@codeit.com)"
+   *       '401':
+   *         $ref: '#/components/responses/Unauthorized'
    */
   contractRouter.get('/customers', controller.getContractCustomers);
   /**
    * @swagger
    * /contracts/users:
-   * get:
-   * tags:
-   * - Contracts
-   * summary: 계약용 담당자 선택 목록 조회
-   * description: 계약 등록/수정 시 사용할 담당자 목록 조회
-   * responses:
-   * '200':
-   * description: 담당자 목록 조회 성공
-   * content:
-   * application/json:
-   * schema:
-   * type: array
-   * items:
-   * $ref: '#/components/schemas/ContractUserOption'
-   * example:
-   * - id: 1
-   * data: "최효정(hjhj@codeit.com)"
-   * - id: 2
-   * data: "김이박(kip@codeit.com)"
-   * - id: 3
-   * data: "최홍만(hm@codeit.com)"
-   * '401':
-   * $ref: '#/components/responses/Unauthorized'
+   *   get:
+   *     tags:
+   *       - Contracts
+   *     summary: 계약용 담당자 선택 목록 조회
+   *     description: 계약 등록/수정 시 사용할 담당자 목록 조회
+   *     responses:
+   *       '200':
+   *         description: 담당자 목록 조회 성공
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 $ref: '#/components/schemas/ContractUserOption'
+   *             example:
+   *               - id: 1
+   *                 data: "최효정(hjhj@codeit.com)"
+   *               - id: 2
+   *                 data: "김이박(kip@codeit.com)"
+   *               - id: 3
+   *                 data: "최홍만(hm@codeit.com)"
+   *       '401':
+   *         $ref: '#/components/responses/Unauthorized'
    */
   contractRouter.get('/users', controller.getContractUsers);
 


### PR DESCRIPTION
## 📌 작업 개요
-  계약서 수정 API를 계약 수정 API를 활용하도록 수정
## 🔗 관련 이슈
- #125

## ✅ 작업 내용

 변경사항 
1. routes.ts

기존 PATCH /:contractId 엔드포인트 제거
계약서 수정은 이제 계약 API에서 처리

2. service.ts

새로운 메서드 3개 추가:

attachDocumentsToContract(): 계약서를 계약에 연결
updateContractDocumentFileNames(): 파일명 업데이트
getContractDocumentsByContractId(): 계약별 계약서 조회



3. repository.ts

새로운 메서드 3개 추가:

attachDocumentsToContract(): DB에서 계약서-계약 연결
updateDocumentFileName(): DB에서 파일명 업데이트
findDocumentsByContractId(): DB에서 계약별 계약서 조회



4. controller.ts

editContractDocuments 메서드 제거
새로운 헬퍼 메서드들 추가 (HTTP 엔드포인트가 아닌 내부 호출용)


5. contracts.service.ts

계약서 관리를 위한 코드 추가
---



## 🧪 테스트 내용 


## ⚠️ 특이사항

