### PR TITLE
fix: contract-document API 수정

### DIFF
--- a/src/cars/service.ts
+++ b/src/cars/service.ts
@@ -1,374 +1,469 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { PrismaClient, Prisma, ContractStatus as PrismaContractStatus } from '@prisma/client';
-import ContractRepository, { ContractSearchBy, ContractWithRelations } from './repository';
-import { CreateContractDto } from './dto/create-contract.dto';
-import { UpdateContractDto } from './dto/update-contract.dto';
-import { mapContract } from './contract.mapper';
-import { refreshAggregatesAfterContractChange } from './contract.aggregates';
+import { Prisma, CarType, CarStatus, PrismaClient } from '@prisma/client';
+import { parse } from 'csv-parse';
+import { Readable } from 'stream';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import stripBomStream from 'strip-bom-stream';
+import { CarResponseDto, CreateCarDTO } from './dto/create-car.dto';
+import CarRepository from './repository';
+import { CarListQueryDto, CarListResponseDto, FindManyCarOptions } from './dto/get-car.dto';
+import { UpdateCarDto } from './dto/update-car.dto';
+import { UploadCarDto } from './dto/upload-car.dto';
+import { ConflictError } from '../common/errors/conflict-error';
 import { NotFoundError } from '../common/errors/not-found-error';
+import { ForbiddenError } from '../common/errors/forbidden-error';
+import { UnauthorizedError } from '../common/errors/unauthorized-error';
+import { AppError } from '../common/errors/app-error';
+import { carStatusToCamelCase, carTypeToKorean } from '../common/utils/car.converter';
 
-type RequestUser = {
-  id: number;
-  companyId: number;
-  name: string;
-  email: string;
-  isAdmin: boolean;
-};
+const BATCH_SIZE = 1000;
 
-type ItemForDropdown = { id: number; data: string };
-
-// 상태 → 응답 키
-const STATUS_KEY: Record<
-  PrismaContractStatus,
-  'carInspection' | 'priceNegotiation' | 'contractDraft' | 'contractSuccessful' | 'contractFailed'
-> = {
-  CAR_INSPECTION: 'carInspection',
-  PRICE_NEGOTIATION: 'priceNegotiation',
-  CONTRACT_DRAFT: 'contractDraft',
-  CONTRACT_SUCCESSFUL: 'contractSuccessful',
-  CONTRACT_FAILED: 'contractFailed',
-};
-
-export class ContractService {
-  private readonly repository: ContractRepository;
-  private readonly prisma?: PrismaClient;
-
-  constructor(prismaOrRepository: PrismaClient | ContractRepository) {
-    this.repository =
-      prismaOrRepository instanceof ContractRepository
-        ? prismaOrRepository
-        : new ContractRepository(prismaOrRepository);
-
-    if (!(prismaOrRepository instanceof ContractRepository)) {
-      this.prisma = prismaOrRepository;
-    }
-  }
-
-  /** 담당자(등록자)만 수정/삭제 가능 */
-  private async assertCanModify(user: RequestUser, contractId: number): Promise<void> {
-    const found = await this.repository.findContractById(contractId);
-    if (!found || Number(found.companyId) !== Number(user.companyId)) {
-      throw new NotFoundError('계약을 찾을 수 없습니다.');
-    }
-    if (Number(found.userId) !== Number(user.id)) {
-      const error: any = new Error('담당자만 수정이 가능합니다');
-      error.statusCode = 403;
-      error.code = 'FORBIDDEN_ONLY_OWNER';
-      throw error;
-    }
-  }
-
-  // ──────────────────────────────────────────────────────────────────────────────
-  // 조회
-  // ──────────────────────────────────────────────────────────────────────────────
-  async getContracts(
-    user: RequestUser,
-    filters: { searchBy?: ContractSearchBy; keyword?: string },
-  ): Promise<ReturnType<typeof mapContract>[]> {
-    const rows = await this.repository.findContracts({
-      companyId: user.companyId,
-      searchBy: filters.searchBy,
-      keyword: filters.keyword ?? '',
-    });
-    return rows.map(mapContract);
-  }
-
-  async getContractsPage(
-    user: RequestUser,
-    params: { searchBy?: ContractSearchBy; keyword?: string; page?: number; pageSize?: number },
-  ): Promise<{
-    currentPage: number;
-    totalPages: number;
-    totalItemCount: number;
-    data: ReturnType<typeof mapContract>[];
-  }> {
-    const page = Math.max(1, params.page ?? 1);
-    const pageSize = Math.min(Math.max(1, params.pageSize ?? 10), 100);
-    const skip = (page - 1) * pageSize;
-
-    const [rows, totalItemCount] = await Promise.all([
-      this.repository.findContracts({
-        companyId: user.companyId,
-        searchBy: params.searchBy,
-        keyword: params.keyword ?? '',
-        skip,
-        take: pageSize,
-      }),
-      this.repository.countContracts({
-        companyId: user.companyId,
-        searchBy: params.searchBy,
-        keyword: params.keyword ?? '',
-      }),
-    ]);
-
-    return {
-      currentPage: page,
-      totalPages: Math.ceil(totalItemCount / pageSize),
-      totalItemCount,
-      data: rows.map(mapContract),
-    };
-  }
-
-  async getContractsGroupedPage(
-    user: RequestUser,
-    params: { searchBy?: ContractSearchBy; keyword?: string; page?: number; pageSize?: number },
-  ): Promise<{
-    currentPage: number;
-    totalPages: number;
-    totalItemCount: number;
-    data: {
-      carInspection: { totalItemCount: number; data: ReturnType<typeof mapContract>[] };
-      priceNegotiation: { totalItemCount: number; data: ReturnType<typeof mapContract>[] };
-      contractDraft: { totalItemCount: number; data: ReturnType<typeof mapContract>[] };
-      contractSuccessful: { totalItemCount: number; data: ReturnType<typeof mapContract>[] };
-      contractFailed: { totalItemCount: number; data: ReturnType<typeof mapContract>[] };
-    };
-  }> {
-    const page = Math.max(1, params.page ?? 1);
-    const pageSize = Math.min(Math.max(1, params.pageSize ?? 10), 100);
-    const skip = (page - 1) * pageSize;
-
-    const statuses: PrismaContractStatus[] = [
-      'CAR_INSPECTION',
-      'PRICE_NEGOTIATION',
-      'CONTRACT_DRAFT',
-      'CONTRACT_SUCCESSFUL',
-      'CONTRACT_FAILED',
-    ];
-
-    const totalPromise = this.repository.countContracts({
-      companyId: user.companyId,
-      searchBy: params.searchBy,
-      keyword: params.keyword ?? '',
-    });
-
-    const perStatusPromises = statuses.flatMap((status) => [
-      this.repository.countContracts({
-        companyId: user.companyId,
-        searchBy: params.searchBy,
-        keyword: params.keyword ?? '',
-        status,
-      }),
-      this.repository.findContracts({
-        companyId: user.companyId,
-        searchBy: params.searchBy,
-        keyword: params.keyword ?? '',
-        status,
-        skip,
-        take: pageSize,
-      }),
-    ]);
-
-    const [totalItemCount, ...countsAndRows] = await Promise.all([
-      totalPromise,
-      ...perStatusPromises,
-    ]);
-
-    const grouped = {
-      carInspection: { totalItemCount: 0, data: [] as ReturnType<typeof mapContract>[] },
-      priceNegotiation: { totalItemCount: 0, data: [] as ReturnType<typeof mapContract>[] },
-      contractDraft: { totalItemCount: 0, data: [] as ReturnType<typeof mapContract>[] },
-      contractSuccessful: { totalItemCount: 0, data: [] as ReturnType<typeof mapContract>[] },
-      contractFailed: { totalItemCount: 0, data: [] as ReturnType<typeof mapContract>[] },
-    };
-
-    statuses.forEach((status, idx) => {
-      const count = countsAndRows[idx * 2] as number;
-      const rows = countsAndRows[idx * 2 + 1] as ContractWithRelations[];
-      const key = STATUS_KEY[status];
-      grouped[key] = { totalItemCount: count, data: rows.map(mapContract) };
-    });
-
-    return {
-      currentPage: page,
-      totalPages: Math.ceil(totalItemCount / pageSize),
-      totalItemCount,
-      data: grouped,
-    };
-  }
-
-  async getContractById(contractId: number) {
-    return this.repository.findContractById(contractId);
-  }
-
-  // ──────────────────────────────────────────────────────────────────────────────
-  // 생성/수정/삭제
-  // ──────────────────────────────────────────────────────────────────────────────
-
-  /** 계약 등록 (가격/상태 계산은 Repository.createContract 내부 처리) */
-  async createContract(
-    user: RequestUser,
-    createPayload: CreateContractDto & { customerId: number; carId: number; userId: number },
-  ) {
-    const finalUserId = createPayload.userId ?? user.id;
-
-    if (this.prisma) {
-      return this.prisma.$transaction(async (tx) => {
-        const repo = new ContractRepository(tx);
-        const created = await repo.createContract({
-          ...createPayload,
-          userId: finalUserId,
-          companyId: user.companyId,
-        });
-
-        await refreshAggregatesAfterContractChange(
-          tx,
-          user.companyId,
-          created.customer?.id ?? null,
-          created.car?.id ?? null,
-        );
-
-        return created;
-      });
-    }
-
-    // (테스트 등 Prisma 미주입 경로)
-    return this.repository.createContract({
-      ...createPayload,
-      userId: finalUserId,
-      companyId: user.companyId,
-    });
-  }
-
-  /** 계약 수정 (담당자 한정, 문서 연결/파일명 변경 포함, 집계 갱신) */
-  async updateContract(user: RequestUser, contractId: number, updatePayload: UpdateContractDto) {
-    await this.assertCanModify(user, contractId);
-
-    if (this.prisma) {
-      return this.prisma.$transaction(async (tx) => {
-        const repo = new ContractRepository(tx);
-        const updated = await repo.updateContract(contractId, updatePayload);
-
-        // 계약서(문서) 연결 및 파일명 변경
-        if (
-          Array.isArray(updatePayload.contractDocuments) &&
-          updatePayload.contractDocuments.length
-        ) {
-          const documentIds = updatePayload.contractDocuments
-            .map((d: any) => (typeof d === 'number' ? d : d?.id))
-            .filter((id: any): id is number => Number.isInteger(id));
-
-          if (documentIds.length) {
-            await ContractService.attachDocumentsToContractTx(
-              tx,
-              user.companyId,
-              contractId,
-              documentIds,
-            );
-          }
-
-          const fileNameUpdates = updatePayload.contractDocuments
-            .map((d: any) => {
-              const id = typeof d === 'number' ? undefined : d?.id;
-              const fileName = typeof d === 'number' ? undefined : d?.fileName;
-              return id && fileName ? { id, fileName } : null;
-            })
-            .filter((v): v is { id: number; fileName: string } => !!v);
-
-          if (fileNameUpdates.length) {
-            await ContractService.updateContractDocumentFileNamesTx(
-              tx,
-              user.companyId,
-              contractId,
-              fileNameUpdates,
-            );
-          }
-        }
-
-        await refreshAggregatesAfterContractChange(
-          tx,
-          user.companyId,
-          updated.customer?.id ?? null,
-          updated.car?.id ?? null,
-        );
-
-        return updated;
-      });
-    }
-
-    // Prisma 미주입 경로(문서 연결/파일명 변경은 생략)
-    return this.repository.updateContract(contractId, updatePayload);
-  }
-
-  /** 계약 삭제 (담당자 한정) */
-  async deleteContract(user: RequestUser, contractId: number) {
-    await this.assertCanModify(user, contractId);
-
-    if (this.prisma) {
-      await this.prisma.$transaction(async (tx) => {
-        const repo = new ContractRepository(tx);
-        const before = await repo.findContractById(contractId);
-
-        await repo.deleteContract(contractId);
-
-        await refreshAggregatesAfterContractChange(
-          tx,
-          user.companyId,
-          before?.customer?.id ?? null,
-          before?.car?.id ?? null,
-        );
-      });
-      return;
-    }
-
-    await this.repository.deleteContract(contractId);
-  }
-
-  // ──────────────────────────────────────────────────────────────────────────────
-  // 드롭다운 소스
-  // ──────────────────────────────────────────────────────────────────────────────
-
-  /** 계약용 차량 선택 목록 (보유중만) */
-  async getContractCars(user: RequestUser): Promise<ItemForDropdown[]> {
-    const cars = await this.repository.findCarsForContract(user.companyId);
-    return cars.map((car) => ({ id: car.id, data: `${car.model}(${car.carNumber})` }));
-  }
-
-  /** 계약용 고객 선택 목록 */
-  async getContractCustomers(user: RequestUser) {
-    return this.repository.findCustomersByCompanyId(user.companyId);
-  }
-
-  /** 계약용 사용자 선택 목록 */
-  async getContractUsers(user: RequestUser) {
-    return this.repository.findUsersByCompanyId(user.companyId);
-  }
-
-  // ──────────────────────────────────────────────────────────────────────────────
-  // 트랜잭션 헬퍼(정적 메서드: ESLint class-methods-use-this 대응)
-  // ──────────────────────────────────────────────────────────────────────────────
-
-  /** 트랜잭션 안에서 문서들을 계약에 연결 */
-  private static async attachDocumentsToContractTx(
-    tx: Prisma.TransactionClient,
-    companyId: number,
-    contractId: number,
-    documentIds: number[],
-  ): Promise<void> {
-    if (!documentIds.length) return;
-    await tx.contractDocument.updateMany({
-      where: { id: { in: documentIds }, contract: { companyId } },
-      data: { contractId },
-    });
-  }
-
-  /** 트랜잭션 안에서 문서 파일명 일괄 변경 */
-  private static async updateContractDocumentFileNamesTx(
-    tx: Prisma.TransactionClient,
-    _companyId: number,
-    contractId: number,
-    items: { id: number; fileName: string }[],
-  ): Promise<void> {
-    if (!items.length) return;
-    await Promise.all(
-      items.map(({ id, fileName }) =>
-        tx.contractDocument.update({
-          where: { id },
-          data: { fileName, contractId },
-        }),
-      ),
-    );
-  }
+export interface CarModelOfManufacturer {
+  manufacturer: string;
+  model: string[];
 }
 
-export default ContractService;
+export interface CarModelListResponseDto {
+  data: CarModelOfManufacturer[];
+}
+
+export default class CarService {
+  private readonly carRepository: CarRepository;
+  private readonly prisma: PrismaClient; // PrismaClient
+
+  constructor(carRepository: CarRepository, prisma: PrismaClient) {
+    this.carRepository = carRepository;
+    this.prisma = prisma;
+  }
+
+  async createCar(data: CreateCarDTO, companyId: number): Promise<CarResponseDto> {
+    // 차량 번호 중복 체크
+    const existingCar = await this.carRepository.findByCarNumber(companyId, data.carNumber);
+    if (existingCar) {
+      throw new ConflictError('이미 존재하는 차량 번호입니다.');
+    }
+
+    const newCar = await this.carRepository.create({
+      ...data,
+      company: {
+        connect: { id: companyId },
+      },
+    });
+
+    return {
+      id: newCar.id,
+      carNumber: newCar.carNumber,
+      manufacturer: newCar.manufacturer,
+      model: newCar.model,
+      type: carTypeToKorean(newCar.type) as CarType,
+      manufacturingYear: newCar.manufacturingYear,
+      mileage: newCar.mileage,
+      price: newCar.price.toNumber(),
+      accidentCount: newCar.accidentCount,
+      explanation: newCar.explanation,
+      accidentDetails: newCar.accidentDetails,
+      status: carStatusToCamelCase(newCar.status) as CarStatus,
+    };
+  }
+
+  async getCarList(query: CarListQueryDto, companyId: number): Promise<CarListResponseDto> {
+    const page = Number(query.page) ?? 1;
+    const pageSize = Number(query.pageSize) ?? 8;
+    const { status, searchBy, keyword } = query;
+
+    const skip = (page - 1) * pageSize;
+    const take = pageSize;
+
+    const whereClause: Prisma.CarWhereInput = {
+      companyId,
+    };
+
+    const statusMap: Record<string, CarStatus> = {
+      possession: CarStatus.POSSESSION,
+      contractProceeding: CarStatus.CONTRACT_PROCEEDING,
+      contractCompleted: CarStatus.CONTRACT_COMPLETED,
+    };
+
+    if (status && statusMap[status]) {
+      whereClause.status = statusMap[status];
+    }
+
+    // 검색 기준, 검색어 필터링
+    if (searchBy && keyword) {
+      if (searchBy === 'carNumber') {
+        whereClause.carNumber = {
+          contains: keyword,
+          mode: 'insensitive',
+        };
+      } else if (searchBy === 'model') {
+        whereClause.model = {
+          contains: keyword,
+          mode: 'insensitive',
+        };
+      }
+    }
+    const findOptions: FindManyCarOptions = {
+      skip,
+      take,
+      where: whereClause,
+      orderBy: { id: 'asc' },
+    };
+
+    const totalItemCount = await this.carRepository.countCars(whereClause);
+    const cars = await this.carRepository.findManyCar(findOptions);
+
+    const carOutputData: CarResponseDto[] = cars.map((car) => ({
+      id: car.id,
+      carNumber: car.carNumber,
+      manufacturer: car.manufacturer,
+      model: car.model,
+      type: carTypeToKorean(car.type) as CarType,
+      manufacturingYear: car.manufacturingYear,
+      mileage: car.mileage,
+      price: car.price.toNumber(),
+      accidentCount: car.accidentCount,
+      explanation: car.explanation,
+      accidentDetails: car.accidentDetails,
+      status: carStatusToCamelCase(car.status) as CarStatus,
+    }));
+    const totalPages = Math.ceil(totalItemCount / pageSize);
+    return {
+      currentPage: page,
+      totalPages,
+      totalItemCount,
+      data: carOutputData,
+    };
+  }
+
+  async updateCar(data: UpdateCarDto, companyId: number, carId: number): Promise<CarResponseDto> {
+    // 차량 존재 여부 확인
+    const existingCar = await this.carRepository.findById(carId);
+    if (!existingCar) {
+      throw new NotFoundError('존재하지 않는 차량입니다.');
+    }
+
+    // 회사 소속 차량인지 확인
+    if (existingCar.companyId !== companyId) {
+      throw new ForbiddenError('회사에 소속된 차량이 아닙니다.');
+    }
+
+    // 업데이트할 데이터 준비
+    const updateData: Prisma.CarUpdateInput = {};
+
+    // 차량 번호 중복 체크
+    if (data.carNumber !== undefined && data.carNumber !== existingCar.carNumber) {
+      const existingCarByNumber = await this.carRepository.findByCarNumber(
+        companyId,
+        data.carNumber,
+      );
+      if (existingCarByNumber) {
+        throw new ConflictError('이미 존재하는 차량 번호입니다.');
+      }
+      updateData.carNumber = data.carNumber;
+    }
+
+    // 업데이트할 필드가 정의되어 있는 경우에만 추가
+    if (data.manufacturer !== undefined) updateData.manufacturer = data.manufacturer;
+    if (data.model !== undefined) updateData.model = data.model;
+    if (data.manufacturingYear !== undefined) updateData.manufacturingYear = data.manufacturingYear;
+    if (data.mileage !== undefined) updateData.mileage = data.mileage;
+    if (data.price !== undefined) updateData.price = data.price;
+    if (data.accidentCount !== undefined) updateData.accidentCount = data.accidentCount;
+    if (data.explanation !== undefined) updateData.explanation = data.explanation;
+    if (data.accidentDetails !== undefined) updateData.accidentDetails = data.accidentDetails;
+
+    const updatedCar = await this.carRepository.update(carId, updateData);
+
+    return {
+      id: updatedCar.id,
+      carNumber: updatedCar.carNumber,
+      manufacturer: updatedCar.manufacturer,
+      model: updatedCar.model,
+      type: updatedCar.type as CarType,
+      manufacturingYear: updatedCar.manufacturingYear,
+      mileage: updatedCar.mileage,
+      price: updatedCar.price.toNumber(),
+      accidentCount: updatedCar.accidentCount,
+      explanation: updatedCar.explanation,
+      accidentDetails: updatedCar.accidentDetails,
+      status: updatedCar.status as CarStatus,
+    };
+  }
+
+  async deleteCar(carId: number, companyId: number): Promise<{ message: string }> {
+    // 차량 존재 여부 확인
+    const existingCar = await this.carRepository.findById(carId);
+    if (!existingCar) {
+      throw new NotFoundError('존재하지 않는 차량입니다.');
+    }
+
+    // 회사 소속 차량인지 확인
+    if (existingCar.companyId !== companyId) {
+      throw new ForbiddenError('회사에 소속된 차량이 아닙니다.');
+    }
+
+    await this.carRepository.delete(carId, companyId);
+    return { message: '차량 삭제 성공' };
+  }
+
+  async getCarDetails(carId: number, userId: number): Promise<CarResponseDto> {
+    // 로그인 확인
+    if (!userId) {
+      throw new UnauthorizedError('로그인이 필요합니다.');
+    }
+    const detailcar = await this.carRepository.findById(carId);
+    if (!detailcar) {
+      throw new NotFoundError('존재하지 않는 차량입니다');
+    }
+    // 차량 정보 반환
+    return {
+      id: detailcar.id,
+      carNumber: detailcar.carNumber,
+      manufacturer: detailcar.manufacturer,
+      model: detailcar.model,
+      type: detailcar.type as CarType,
+      manufacturingYear: detailcar.manufacturingYear,
+      mileage: detailcar.mileage,
+      price: detailcar.price.toNumber(),
+      accidentCount: detailcar.accidentCount,
+      explanation: detailcar.explanation,
+      accidentDetails: detailcar.accidentDetails,
+      status: detailcar.status as CarStatus,
+    };
+  }
+
+  async uploadCars(fileBuffer: Buffer, authCompanyId: number): Promise<{ message: string }> {
+    // 유효성 검사 및 타입 변환이 끝난 후 DB에 삽입 될 record
+    const recordsToInsert: Prisma.CarCreateManyInput[] = [];
+    // 실패한 record
+    const failedRecords: any[] = [];
+    // CSV 파일의 줄 갯수
+    let totalRecords = 0;
+
+    const parser = parse({
+      delimiter: ',',
+      columns: true,
+      skip_empty_lines: true,
+      trim: true,
+    });
+
+    // 데이터(fileBuffer)를 한 줄 씩 읽는 기능
+    const readableStream = Readable.from(fileBuffer).pipe(stripBomStream());
+
+    return new Promise((resolve, reject) => {
+      /**
+       * parser.pause()를 사용하여
+       * 한줄의 레코드가 처리될 때까지 일시정지
+       */
+      readableStream
+        .pipe(parser)
+        .on('data', async (record: any) => {
+          parser.pause();
+
+          totalRecords += 1;
+
+          /**
+           * 'plainToInstance'를 사용하여 일반 자바스크립트 객체(record)를
+           * 'UploadCarDto' 클래스 인스턴스로 변환
+           * 해당 과정이 있어야 유효성 검사가 가능해짐
+           *
+           * 유효성 검사 실패 시 'failedRecords'에 추가
+           */
+          try {
+            const carRecordDto = plainToInstance(UploadCarDto, record, {
+              excludeExtraneousValues: true,
+            });
+            const errors = await validate(carRecordDto);
+
+            if (errors.length > 0) {
+              failedRecords.push({
+                lineNumber: totalRecords,
+                record,
+                errors: errors.map((err) => Object.values(err.constraints || {})).flat(),
+              });
+              return;
+            }
+
+            /**
+             * CSV 파일의 문자열을
+             * Prisma에서 사용하는 Enum으로 변환
+             * 정의되지 않은 차량 유형일 경우 오류로 처리
+             */
+            let prismaCarType: CarType;
+            switch (carRecordDto.type) {
+              case '경·소형':
+                prismaCarType = CarType.COMPACT;
+                break;
+              case '준중·중형':
+                prismaCarType = CarType.MIDSIZE;
+                break;
+              case '대형':
+                prismaCarType = CarType.FULLSIZE;
+                break;
+              case '스포츠카':
+                prismaCarType = CarType.SPORTS;
+                break;
+              case 'SUV':
+                prismaCarType = CarType.SUV;
+                break;
+              default:
+                failedRecords.push({
+                  lineNumber: totalRecords,
+                  record,
+                  errors: [`유효하지 않은 차량 유형: ${carRecordDto.type}`],
+                });
+                return;
+            }
+
+            const existingCar = await this.carRepository.findByCarNumber(
+              authCompanyId,
+              carRecordDto.carNumber,
+            );
+            if (existingCar) {
+              failedRecords.push({
+                lineNumber: totalRecords,
+                record,
+                errors: [
+                  `이미 존재하는 차량 번호입니다. (회사 ID: ${authCompanyId}, 차량 번호: ${carRecordDto.carNumber})`,
+                ],
+              });
+              return;
+            }
+
+            /**
+             * 모든 유효성 검사를 통과한 데이터를
+             * Prisma의 'CarCreateManyInput' 타입에 맞게 최종 객체로 변환
+             */
+            const carToCreate: Prisma.CarCreateManyInput = {
+              carNumber: carRecordDto.carNumber,
+              manufacturer: carRecordDto.manufacturer,
+              model: carRecordDto.model,
+              type: prismaCarType,
+              manufacturingYear: carRecordDto.manufacturingYear,
+              mileage: carRecordDto.mileage,
+              price: new Prisma.Decimal(carRecordDto.price),
+              accidentCount: carRecordDto.accidentCount || 0,
+              explanation: carRecordDto.explanation,
+              accidentDetails: carRecordDto.accidentDetails,
+              companyId: authCompanyId, // 회사 ID 추가
+            };
+
+            recordsToInsert.push(carToCreate);
+
+            /**
+             * 데이터를 BATCH_SIZE만큼 모아서
+             * processBatch 함수로 한번에 처리
+             * 처리 완료 후에는 recordsToInsert 배열을 초기화하여 다음 배치 데이터를 받을 준비함
+             */
+            if (recordsToInsert.length >= BATCH_SIZE) {
+              await this.processBatch(recordsToInsert, failedRecords);
+              recordsToInsert.length = 0;
+            }
+          } catch (error: any) {
+            failedRecords.push({
+              lineNumber: totalRecords,
+              record,
+              errors: [`예상치 못한 처리 오류: ${error.message}`],
+            });
+          } finally {
+            // 모든 처리가 완료되면, 다음 레코드를 받기 위해 스트림 재개
+            parser.resume();
+          }
+        })
+        /**
+         * 파일의 모든 레코드 처리가 끝나면 실행될 코드
+         * CSV parser가 파일의 끝에 도달하면 이벤트 발생
+         *
+         * 남은 데이터 처리:
+         * 배열에 남아있는 레코드를 processBatch 호출하여 모두 저장
+         *
+         * 최종 메세지 생성
+         * Promise 완료로 'resolve()'를 통해 최종 메세지를 반환
+         */
+        .on('end', async () => {
+          if (recordsToInsert.length > 0) {
+            await this.processBatch(recordsToInsert, failedRecords);
+          }
+
+          let message = 'CSV 파일 처리가 완료되었습니다.';
+          if (failedRecords.length > 0) {
+            message += ` ${failedRecords.length}개의 레코드 처리에 실패했습니다.`;
+            console.warn(`CSV Upload Failed Records for company ${authCompanyId}:`, failedRecords);
+          }
+
+          resolve({ message });
+        })
+        /**
+         * 파싱 오류 처리
+         * 'reject()'를 호출하여 Promise를 실패 상태로 전환
+         */
+        .on('error', (err) => {
+          console.error('CSV Parsing Error:', err);
+          reject(new AppError(`CSV 파싱 중 오류 발생: ${err.message}`, 500));
+        });
+    });
+  }
+
+  /**
+   * `batch`에 담긴 레코드들을 데이터베이스에 한 번에 저장
+   *
+   * 이 함수는 `uploadCars` 메서드에서
+   * 1) 데이터가 `BATCH_SIZE`만큼 쌓였을 때
+   * 2) CSV 파일의 끝에 도달했을 때
+   * 호출됨
+   *
+   * @param batch - 데이터베이스에 삽입할 레코드들의 배열
+   * @param failedRecords - 삽입 실패 시 오류를 기록할 배열
+   */
+  private async processBatch(
+    batch: Prisma.CarCreateManyInput[],
+    failedRecords: any[],
+  ): Promise<void> {
+    if (batch.length === 0) {
+      return;
+    }
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        const carRepositoryInTransaction = new CarRepository(tx);
+        await carRepositoryInTransaction.createMany(batch);
+      });
+      console.log(`Batch inserted: ${batch.length} records.`);
+    } catch (dbError: any) {
+      console.error('Batch DB insertion failed:', dbError);
+      batch.forEach((record) => {
+        failedRecords.push({
+          record,
+          errors: [`DB 삽입 실패: ${dbError.message}`],
+        });
+      });
+    }
+  }
+
+  async getCarModelList(): Promise<CarModelListResponseDto> {
+    // 중복되지 않는 제조사-모델 쌍 가져오기
+    const distinctCarPairs = await this.carRepository.findManyCarModel();
+
+    const manufacturerMap = distinctCarPairs.reduce((acc, pair) => {
+      const { manufacturer, model } = pair;
+
+      // Map에 해당 제조사가 없으면 빈 배열로 초기화하고, 모델 추가
+      if (!acc.has(manufacturer)) {
+        acc.set(manufacturer, []);
+      }
+      acc.get(manufacturer)?.push(model);
+      return acc;
+    }, new Map<string, string[]>());
+
+    // ResponseDTO 형식으로 변환
+    const data: CarModelOfManufacturer[] = Array.from(manufacturerMap.entries()).map(
+      ([manufacturer, models]) => ({
+        manufacturer,
+        model: models.sort(), // 모델 목록을 알파벳 순으로 정렬
+      }),
+    );
+
+    data.sort((a, b) => a.manufacturer.localeCompare(b.manufacturer));
+
+    return { data };
+  }
+}

--- a/src/common/email.service.ts
+++ b/src/common/email.service.ts
@@ -1,45 +1,81 @@
-import nodemailer from 'nodemailer';
+import nodemailer, { Transporter, SendMailOptions } from 'nodemailer';
 
-interface EmailAttachment {
-  filename: string;
-  path: string;
-}
+type EmailAttachment = { filename: string; path: string };
 
 export default class EmailService {
-  private transporter: nodemailer.Transporter;
+  private transporter: Transporter | null = null;
+  private readonly from =
+    process.env.SMTP_FROM || process.env.EMAIL_FROM || 'no-reply@carmate.local';
 
-  constructor() {
+  private readonly disabled = process.env.SMTP_DISABLED === 'true';
+
+  /** 트랜스포터 생성(없으면 dev에서 Ethereal, prod에선 비활성) */
+  private async getTransporter(): Promise<Transporter | null> {
+    if (this.disabled) return null;
+    if (this.transporter) return this.transporter;
+
+    const host = process.env.SMTP_HOST;
+    const port = Number(process.env.SMTP_PORT || 0);
+    const user = process.env.SMTP_USER;
+    const pass = process.env.SMTP_PASS;
+    const secure = String(process.env.SMTP_SECURE || '').toLowerCase() === 'true' || port === 465;
+
+    // 정상 설정이 있으면 그걸 사용
+    if (host && user && pass) {
+      this.transporter = nodemailer.createTransport({
+        host,
+        port: port || (secure ? 465 : 587),
+        secure, // 465면 true, 587이면 false
+        auth: { user, pass },
+      });
+      return this.transporter;
+    }
+
+    // 설정이 없을 때: 운영은 끄고, 개발은 Ethereal 테스트 SMTP 사용
+    if (process.env.NODE_ENV === 'production') return null;
+
+    const test = await nodemailer.createTestAccount();
     this.transporter = nodemailer.createTransport({
-      host: process.env.SMTP_HOST || 'smtp.gmail.com',
-      port: parseInt(process.env.SMTP_PORT || '587', 10),
+      host: 'smtp.ethereal.email',
+      port: 587,
       secure: false,
-      auth: {
-        user: process.env.SMTP_USER,
-        pass: process.env.SMTP_PASS,
-      },
+      auth: { user: test.user, pass: test.pass },
     });
+    return this.transporter;
   }
 
   async sendEmail(
-    to: string,
+    to: string | null | undefined,
     subject: string,
     html: string,
-    attachments?: EmailAttachment[],
+    attachments: EmailAttachment[] = [],
   ): Promise<void> {
     try {
-      const mailOptions: nodemailer.SendMailOptions = {
-        from: process.env.SMTP_FROM || 'noreply@carmate.com',
+      if (!to) {
+        console.warn('[email] 수신자 없음 → 전송 스킵');
+        return;
+      }
+      const transporter = await this.getTransporter();
+      if (!transporter) {
+        console.warn('[email] SMTP 미설정/비활성 → 전송 스킵');
+        return;
+      }
+
+      const mailOptions: SendMailOptions = {
+        from: this.from,
         to,
         subject,
         html,
         attachments,
       };
 
-      await this.transporter.sendMail(mailOptions);
-      console.log(`이메일 발송 성공: ${to}`);
-    } catch (error) {
-      console.error(`이메일 발송 실패: ${to}`, error);
-      // 이메일 발송 실패해도 프로세스는 계속 진행
+      const info = await transporter.sendMail(mailOptions);
+      const preview = nodemailer.getTestMessageUrl(info);
+      if (preview) console.log('[email] Preview URL:', preview);
+      console.log(`[email] sent → ${to}`);
+    } catch (err) {
+      console.error('[email] 전송 실패:', (err as Error).message);
+      // 실패해도 플로우는 계속
     }
   }
 }

--- a/src/common/utils/filename.ts
+++ b/src/common/utils/filename.ts
@@ -1,0 +1,11 @@
+export function toUtf8Filename(name: string): string {
+  if (!name) return name;
+  try {
+    return Buffer.from(name, 'latin1').toString('utf8'); // 깨진 한글 복원
+  } catch {
+    return name;
+  }
+}
+export function sanitizeFilename(name: string): string {
+  return name.replace(/[\\/:*?"<>|]/g, '_'); // OS 예약문자 제거
+}

--- a/src/contract-documents/contract-documents.routes.ts
+++ b/src/contract-documents/contract-documents.routes.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { Router } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { isAuthenticated } from '../middlewares/passport.middlewares';
@@ -10,296 +9,165 @@ import ContractDocumentsService from './service';
 import ContractDocumentsController from './controller';
 
 import GetContractDocumentsDto from './dto/get-contract-documents.dto';
+import UploadContractDocumentDto from './dto/upload-contract-document.dto';
+import DownloadContractDocumentsDto from './dto/download-contract-documents.dto';
 import EditContractDocumentsDto from './dto/edit-contract-documents.dto';
 
-/**
- * 계약서 라우터 팩토리
- */
+/** 타입 문제로 미들웨어 import 에러가 났던 지점 → 파일 안에서 간단히 정의 */
+const normalizeContractIdInBody = (req: any, _res: any, next: any) => {
+  const toNum = (v: unknown): number | undefined => {
+    if (v == null) return undefined;
+    const n = Number(v as any);
+    return Number.isFinite(n) ? n : undefined;
+  };
+
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const params = (req.params ?? {}) as Record<string, unknown>;
+  const query = (req.query ?? {}) as Record<string, unknown>;
+
+  // 자주 오는 모든 키 수집
+  const candidates: unknown[] = [
+    body.contractId,
+    body.selectedContractId,
+    body.selectedDealId,
+    body.dealId,
+    body.deal_id,
+    body.contract_id,
+    body.contract,
+    body.id,
+    query.contractId,
+    query.id,
+    params.contractId,
+    req.header?.('x-contract-id'),
+  ];
+
+  for (let i = 0; i < candidates.length; i += 1) {
+    const n = toNum(candidates[i]);
+    if (typeof n === 'number') {
+      (req.body as any).contractId = n;
+      break;
+    }
+  }
+
+  // 문자열에서 [차량번호]나 숫자만 있는 값으로 역추정
+  if (typeof (req.body as any).contractId !== 'number') {
+    const strings: string[] = [];
+    Object.values(body).forEach((v) => {
+      if (typeof v === 'string') strings.push(v);
+    });
+    const numFromText = strings
+      .flatMap((s) => s.match(/\d+/g) ?? [])
+      .map((t) => Number(t))
+      .find((n) => Number.isInteger(n));
+    if (Number.isInteger(numFromText)) (req.body as any).contractId = numFromText;
+  }
+
+  next();
+};
+
+const stripUnknownFormKeys = (req: any, _res: any, next: any) => {
+  const allow = new Set([
+    'contractId',
+    'files',
+    'file',
+    'documents',
+    'files[]',
+    'file[]',
+    'documents[]',
+    'deleteDocumentIds',
+    'deletedDocumentIds',
+    'deleteIds',
+    'ids',
+    'documentIds',
+    'deleteDocumentIds[]',
+  ]);
+  if (req.body && typeof req.body === 'object') {
+    const keys = Object.keys(req.body);
+    for (let i = 0; i < keys.length; i += 1) {
+      const k = keys[i]!;
+      if (!allow.has(k)) delete (req.body as any)[k];
+    }
+  }
+  next();
+};
+
+const debugPrintForm = (req: any, _res: any, next: any) => {
+  const body = req.body ?? {};
+  const files = Array.isArray(req.files)
+    ? req.files.map((f: any) => ({
+        field: f.fieldname,
+        name: f.originalname,
+        size: f.size,
+        path: f.path,
+      }))
+    : req.files;
+  console.log('[CDOC] url=', req.originalUrl);
+  console.log('[CDOC] bodyKeys=', Object.keys(body));
+  console.log('[CDOC] body.contractId=', body.contractId);
+  console.log('[CDOC] files=', files);
+  next();
+};
+
 const createContractDocumentsRouter = (prisma: PrismaClient) => {
   const router = Router();
 
-  // DI
-  const repo = new ContractDocumentsRepository(prisma);
-  const svc = new ContractDocumentsService(repo);
-  const ctl = new ContractDocumentsController(svc);
+  const repository = new ContractDocumentsRepository(prisma);
+  const service = new ContractDocumentsService(repository);
+  const controller = new ContractDocumentsController(service);
 
-  /**
-   * @swagger
-   * tags:
-   *   name: ContractDocuments
-   *   description: 계약서 업로드/조회/다운로드/수정 API
-   */
-
-  /**
-   * @swagger
-   * /contractDocuments:
-   *   get:
-   *     tags: [ContractDocuments]
-   *     summary: 계약서 목록 조회(페이지네이션)
-   *     security: [{ bearerAuth: [] }]
-   *     parameters:
-   *       - in: query
-   *         name: page
-   *         schema: { type: integer, default: 1, minimum: 1 }
-   *       - in: query
-   *         name: pageSize
-   *         schema: { type: integer, default: 8, minimum: 1, maximum: 100 }
-   *       - in: query
-   *         name: searchBy
-   *         schema:
-   *           type: string
-   *           enum: [contractName, userName, carNumber]
-   *         description: 검색 기준(계약명/담당자/차량번호)
-   *       - in: query
-   *         name: keyword
-   *         schema: { type: string }
-   *     responses:
-   *       200:
-   *         description: 성공
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: object
-   *               properties:
-   *                 currentPage: { type: integer }
-   *                 totalPages: { type: integer }
-   *                 totalItemCount: { type: integer }
-   *                 data:
-   *                   type: array
-   *                   items:
-   *                     type: object
-   *                     properties:
-   *                       id: { type: integer, description: 계약 ID }
-   *                       contractName: { type: string }
-   *                       resolutionDate: { type: string, description: 'YYYY-MM-DD' }
-   *                       documentsCount: { type: integer }
-   *                       manager: { type: string }
-   *                       carNumber: { type: string }
-   *                       documents:
-   *                         type: array
-   *                         items:
-   *                           type: object
-   *                           properties:
-   *                             id: { type: integer, description: 문서 ID }
-   *                             fileName: { type: string, description: 목록/모달 표시명 }
-   */
+  // 목록(문서수/담당자 포함)
   router.get(
     '/',
     isAuthenticated,
     validateDto(GetContractDocumentsDto),
-    ctl.getContractDocuments,
+    controller.getContractDocuments,
   );
 
-  /**
-   * @swagger
-   * /contractDocuments/draft:
-   *   get:
-   *     tags: [ContractDocuments]
-   *     summary: 업로드 대상 드래프트 계약(드롭다운)
-   *     description: "{ id, name } 형태"
-   *     security: [{ bearerAuth: [] }]
-   *     responses:
-   *       200:
-   *         description: 성공
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: array
-   *               items:
-   *                 type: object
-   *                 properties:
-   *                   id: { type: integer }
-   *                   name: { type: string, example: "[39가7412] 홍길동 소나타" }
-   */
-  router.get('/draft', isAuthenticated, ctl.getDraftContracts);
+  // 드롭박스: 보드에 보이는 상태(가격협의/계약서작성중)만
+  router.get('/draft', isAuthenticated, controller.getDraftContractsForDropdown);
 
-  /**
-   * @swagger
-   * /contractDocuments/draft/dropdown:
-   *   get:
-   *     tags: [ContractDocuments]
-   *     summary: 업로드 대상 드래프트 계약(다른 프론트 스펙)
-   *     description: "{ id, data } 형태"
-   *     security: [{ bearerAuth: [] }]
-   *     responses:
-   *       200:
-   *         description: 성공
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: array
-   *               items:
-   *                 type: object
-   *                 properties:
-   *                   id: { type: integer }
-   *                   data: { type: string, example: "[39가7412] 홍길동 소나타" }
-   */
-  router.get('/draft/dropdown', isAuthenticated, ctl.getDraftContractsForDropdown);
+  // 업로드(바디 기반) — ❗ 경로는 반드시 '/contractDocuments/upload'
+  router.post(
+    '/upload',
+    isAuthenticated,
+    upload.any(),
+    debugPrintForm,
+    normalizeContractIdInBody,
+    stripUnknownFormKeys,
+    validateDto(UploadContractDocumentDto),
+    controller.uploadContractDocuments,
+  );
 
-  /**
-   * @swagger
-   * /contractDocuments/upload:
-   *   post:
-   *     tags: [ContractDocuments]
-   *     summary: 계약서 업로드
-   *     description: |
-   *       - 프론트가 form-data로 파일을 보냅니다.
-   *       - `contractId`는 params/body/query/대체키(selectedContractId, dealId 등) 어느 쪽이든 허용합니다.
-   *       - `files` 필드명이 아니어도 됩니다(서버는 multer.any()로 어떤 필드명이 와도 수집).
-   *     security: [{ bearerAuth: [] }]
-   *     requestBody:
-   *       required: true
-   *       content:
-   *         multipart/form-data:
-   *           schema:
-   *             type: object
-   *             properties:
-   *               contractId:
-   *                 type: integer
-   *                 description: 계약 ID(없으면 서버가 단 1건인 드래프트를 자동 선택)
-   *               files:
-   *                 type: array
-   *                 items: { type: string, format: binary }
-   *                 description: 업로드 파일(최대 10개, 각 10MB)
-   *     responses:
-   *       201:
-   *         description: 업로드 성공
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: object
-   *               properties:
-   *                 message: { type: string }
-   *                 contractDocumentId: { type: integer }
-   *       400:
-   *         description: 잘못된 요청(파일 없음, 계약 ID 부재 등)
-   */
-  router.post('/upload', isAuthenticated, upload.any(), ctl.uploadContractDocuments);
+  // 업로드(경로 파라미터 기반)
+  router.post(
+    '/:contractId',
+    isAuthenticated,
+    upload.any(),
+    debugPrintForm,
+    normalizeContractIdInBody,
+    validateDto(UploadContractDocumentDto),
+    controller.uploadContractDocuments,
+  );
 
-  /**
-   * @swagger
-   * /contractDocuments/{contractId}/upload:
-   *   post:
-   *     tags: [ContractDocuments]
-   *     summary: 계약서 업로드(경로 파라미터로 계약 ID 전달)
-   *     security: [{ bearerAuth: [] }]
-   *     parameters:
-   *       - in: path
-   *         name: contractId
-   *         required: true
-   *         schema: { type: integer }
-   *     requestBody:
-   *       required: true
-   *       content:
-   *         multipart/form-data:
-   *           schema:
-   *             type: object
-   *             properties:
-   *               files:
-   *                 type: array
-   *                 items: { type: string, format: binary }
-   *     responses:
-   *       201:
-   *         description: 업로드 성공
-   */
-  router.post('/:contractId/upload', isAuthenticated, upload.any(), ctl.uploadContractDocuments);
-
-  /**
-   * @swagger
-   * /contractDocuments/{contractDocumentId}/download:
-   *   get:
-   *     tags: [ContractDocuments]
-   *     summary: 단일 문서 다운로드
-   *     security: [{ bearerAuth: [] }]
-   *     parameters:
-   *       - in: path
-   *         name: contractDocumentId
-   *         required: true
-   *         schema: { type: integer }
-   *     responses:
-   *       200:
-   *         description: 파일 스트림
-   *         content:
-   *           application/octet-stream:
-   *             schema: { type: string, format: binary }
-   *       404:
-   *         description: 문서를 찾을 수 없음
-   */
-  router.get('/:contractDocumentId/download', isAuthenticated, ctl.downloadSingleDocument);
-
-  /**
-   * @swagger
-   * /contractDocuments/download:
-   *   post:
-   *     tags: [ContractDocuments]
-   *     summary: 다중 문서 ZIP 다운로드
-   *     security: [{ bearerAuth: [] }]
-   *     requestBody:
-   *       required: true
-   *       content:
-   *         application/json:
-   *           schema:
-   *             type: object
-   *             required: [contractDocumentIds]
-   *             properties:
-   *               contractDocumentIds:
-   *                 type: array
-   *                 items: { type: integer }
-   *                 example: [1,2,3]
-   *     responses:
-   *       200:
-   *         description: zip 파일
-   *         content:
-   *           application/zip:
-   *             schema: { type: string, format: binary }
-   */
-  router.post('/download', isAuthenticated, ctl.downloadMultipleDocuments);
-
-  /**
-   * @swagger
-   * /contractDocuments/{contractId}:
-   *   patch:
-   *     tags: [ContractDocuments]
-   *     summary: 계약서 수정(삭제 + 추가)
-   *     description: |
-   *       - 삭제: `deleteDocumentIds`에 [1,2] 또는 "1,2" 형태 허용  
-   *       - 추가: multipart/form-data로 파일 업로드  
-   *     security: [{ bearerAuth: [] }]
-   *     parameters:
-   *       - in: path
-   *         name: contractId
-   *         required: true
-   *         schema: { type: integer }
-   *     requestBody:
-   *       required: true
-   *       content:
-   *         multipart/form-data:
-   *           schema:
-   *             type: object
-   *             properties:
-   *               deleteDocumentIds:
-   *                 oneOf:
-   *                   - type: array
-   *                     items: { type: integer }
-   *                     example: [10, 11]
-   *                   - type: string
-   *                     example: "10,11"
-   *               files:
-   *                 type: array
-   *                 items: { type: string, format: binary }
-   *                 description: 추가할 파일(선택)
-   *     responses:
-   *       200:
-   *         description: 수정 성공
-   *       400:
-   *         description: 잘못된 요청(계약 불일치/제한 초과 등)
-   */
+  // 수정(추가/삭제)
   router.patch(
     '/:contractId',
     isAuthenticated,
     upload.any(),
+    debugPrintForm,
     validateDto(EditContractDocumentsDto),
-    ctl.editContractDocuments,
+    controller.editContractDocuments,
+  );
+
+  // 단일 다운로드
+  router.get('/:contractDocumentId/download', isAuthenticated, controller.downloadSingleDocument);
+
+  // 다중 다운로드
+  router.post(
+    '/download',
+    isAuthenticated,
+    validateDto(DownloadContractDocumentsDto),
+    controller.downloadMultipleDocuments,
   );
 
   return router;

--- a/src/contract-documents/contract-documents.routes.ts
+++ b/src/contract-documents/contract-documents.routes.ts
@@ -1,345 +1,305 @@
+/* eslint-disable */
 import { Router } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { isAuthenticated } from '../middlewares/passport.middlewares';
 import validateDto from '../common/utils/validate.dto';
 import upload from '../middlewares/upload.middleware';
-import ContractDocumentsController from './controller';
-import ContractDocumentsService from './service';
-import ContractDocumentsRepository from './repository';
-import GetContractDocumentsDto from './dto/get-contract-documents.dto';
-import UploadContractDocumentDto from './dto/upload-contract-document.dto';
-import DownloadContractDocumentsDto from './dto/download-contract-documents.dto';
 
+import ContractDocumentsRepository from './repository';
+import ContractDocumentsService from './service';
+import ContractDocumentsController from './controller';
+
+import GetContractDocumentsDto from './dto/get-contract-documents.dto';
+import EditContractDocumentsDto from './dto/edit-contract-documents.dto';
+
+/**
+ * 계약서 라우터 팩토리
+ */
 const createContractDocumentsRouter = (prisma: PrismaClient) => {
   const router = Router();
 
-  // 의존성 주입
-  const contractDocumentsRepository = new ContractDocumentsRepository(prisma);
-  const contractDocumentsService = new ContractDocumentsService(contractDocumentsRepository);
-  const contractDocumentsController = new ContractDocumentsController(contractDocumentsService);
+  // DI
+  const repo = new ContractDocumentsRepository(prisma);
+  const svc = new ContractDocumentsService(repo);
+  const ctl = new ContractDocumentsController(svc);
+
+  /**
+   * @swagger
+   * tags:
+   *   name: ContractDocuments
+   *   description: 계약서 업로드/조회/다운로드/수정 API
+   */
 
   /**
    * @swagger
    * /contractDocuments:
    *   get:
-   *     tags:
-   *       - ContractDocuments
-   *     summary: 계약서 목록 조회
-   *     description: 등록된 계약서 목록 조회
-   *     security:
-   *       - bearerAuth: []
+   *     tags: [ContractDocuments]
+   *     summary: 계약서 목록 조회(페이지네이션)
+   *     security: [{ bearerAuth: [] }]
    *     parameters:
    *       - in: query
    *         name: page
-   *         schema:
-   *           type: integer
-   *           default: 1
-   *         description: 페이지 번호
+   *         schema: { type: integer, default: 1, minimum: 1 }
    *       - in: query
    *         name: pageSize
-   *         schema:
-   *           type: integer
-   *           default: 8
-   *         description: 페이지당 아이템 수
+   *         schema: { type: integer, default: 8, minimum: 1, maximum: 100 }
    *       - in: query
    *         name: searchBy
    *         schema:
    *           type: string
-   *           enum: [contractName, userName]
-   *         description: 검색 기준
+   *           enum: [contractName, userName, carNumber]
+   *         description: 검색 기준(계약명/담당자/차량번호)
    *       - in: query
    *         name: keyword
-   *         schema:
-   *           type: string
-   *         description: 검색 키워드
+   *         schema: { type: string }
    *     responses:
    *       200:
-   *         description: 계약서 목록 조회 성공
+   *         description: 성공
    *         content:
    *           application/json:
    *             schema:
    *               type: object
    *               properties:
-   *                 currentPage:
-   *                   type: integer
-   *                 totalPages:
-   *                   type: integer
-   *                 totalItemCount:
-   *                   type: integer
+   *                 currentPage: { type: integer }
+   *                 totalPages: { type: integer }
+   *                 totalItemCount: { type: integer }
    *                 data:
    *                   type: array
    *                   items:
    *                     type: object
    *                     properties:
-   *                       id:
-   *                         type: integer
-   *                       contractName:
-   *                         type: string
-   *                       resolutionDate:
-   *                         type: string
-   *                         format: date
-   *                       documentsCount:
-   *                         type: integer
-   *                       manager:
-   *                         type: string
-   *                       carNumber:
-   *                         type: string
+   *                       id: { type: integer, description: 계약 ID }
+   *                       contractName: { type: string }
+   *                       resolutionDate: { type: string, description: 'YYYY-MM-DD' }
+   *                       documentsCount: { type: integer }
+   *                       manager: { type: string }
+   *                       carNumber: { type: string }
    *                       documents:
    *                         type: array
    *                         items:
    *                           type: object
    *                           properties:
-   *                             id:
-   *                               type: integer
-   *                             fileName:
-   *                               type: string
-   *       401:
-   *         description: 인증이 필요합니다
+   *                             id: { type: integer, description: 문서 ID }
+   *                             fileName: { type: string, description: 목록/모달 표시명 }
    */
-
-  // 계약서 목록 조회
   router.get(
     '/',
     isAuthenticated,
     validateDto(GetContractDocumentsDto),
-    contractDocumentsController.getContractDocuments,
+    ctl.getContractDocuments,
   );
+
+  /**
+   * @swagger
+   * /contractDocuments/draft:
+   *   get:
+   *     tags: [ContractDocuments]
+   *     summary: 업로드 대상 드래프트 계약(드롭다운)
+   *     description: "{ id, name } 형태"
+   *     security: [{ bearerAuth: [] }]
+   *     responses:
+   *       200:
+   *         description: 성공
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 type: object
+   *                 properties:
+   *                   id: { type: integer }
+   *                   name: { type: string, example: "[39가7412] 홍길동 소나타" }
+   */
+  router.get('/draft', isAuthenticated, ctl.getDraftContracts);
+
+  /**
+   * @swagger
+   * /contractDocuments/draft/dropdown:
+   *   get:
+   *     tags: [ContractDocuments]
+   *     summary: 업로드 대상 드래프트 계약(다른 프론트 스펙)
+   *     description: "{ id, data } 형태"
+   *     security: [{ bearerAuth: [] }]
+   *     responses:
+   *       200:
+   *         description: 성공
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 type: object
+   *                 properties:
+   *                   id: { type: integer }
+   *                   data: { type: string, example: "[39가7412] 홍길동 소나타" }
+   */
+  router.get('/draft/dropdown', isAuthenticated, ctl.getDraftContractsForDropdown);
 
   /**
    * @swagger
    * /contractDocuments/upload:
    *   post:
-   *     tags:
-   *       - ContractDocuments
+   *     tags: [ContractDocuments]
    *     summary: 계약서 업로드
-   *     description: 계약서 파일 업로드 (최대 10개, 각 파일 최대 10MB)
-   *     security:
-   *       - bearerAuth: []
+   *     description: |
+   *       - 프론트가 form-data로 파일을 보냅니다.
+   *       - `contractId`는 params/body/query/대체키(selectedContractId, dealId 등) 어느 쪽이든 허용합니다.
+   *       - `files` 필드명이 아니어도 됩니다(서버는 multer.any()로 어떤 필드명이 와도 수집).
+   *     security: [{ bearerAuth: [] }]
    *     requestBody:
    *       required: true
    *       content:
    *         multipart/form-data:
    *           schema:
    *             type: object
-   *             required:
-   *               - contractId
-   *               - files
    *             properties:
    *               contractId:
    *                 type: integer
-   *                 description: 계약 ID
-   *                 example: 1
+   *                 description: 계약 ID(없으면 서버가 단 1건인 드래프트를 자동 선택)
    *               files:
    *                 type: array
-   *                 items:
-   *                   type: string
-   *                   format: binary
-   *                 maxItems: 10
-   *                 description: 업로드할 파일들 (최대 10개, 각 10MB)
+   *                 items: { type: string, format: binary }
+   *                 description: 업로드 파일(최대 10개, 각 10MB)
    *     responses:
-   *       200:
-   *         description: 계약서 업로드 성공
+   *       201:
+   *         description: 업로드 성공
    *         content:
    *           application/json:
    *             schema:
    *               type: object
    *               properties:
-   *                 message:
-   *                   type: string
-   *                   example: "계약서 업로드 성공"
-   *                 contractDocumentId:
-   *                   type: integer
+   *                 message: { type: string }
+   *                 contractDocumentId: { type: integer }
    *       400:
-   *         description: 잘못된 요청
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: object
-   *               properties:
-   *                 message:
-   *                   type: string
-   *                   example: "파일이 없습니다"
-   *       401:
-   *         description: 인증이 필요합니다
+   *         description: 잘못된 요청(파일 없음, 계약 ID 부재 등)
    */
-  // 계약서 추가용 계약 목록 조회
-  router.get('/draft', isAuthenticated, contractDocumentsController.getContractsForDraft);
+  router.post('/upload', isAuthenticated, upload.any(), ctl.uploadContractDocuments);
 
   /**
    * @swagger
-   * /contractDocuments/upload:
+   * /contractDocuments/{contractId}/upload:
    *   post:
-   *     tags:
-   *       - ContractDocuments
-   *     summary: 계약서 업로드
-   *     description: 계약서 파일 업로드 (최대 10개, 각 파일 최대 10MB)
-   *     security:
-   *       - bearerAuth: []
+   *     tags: [ContractDocuments]
+   *     summary: 계약서 업로드(경로 파라미터로 계약 ID 전달)
+   *     security: [{ bearerAuth: [] }]
+   *     parameters:
+   *       - in: path
+   *         name: contractId
+   *         required: true
+   *         schema: { type: integer }
    *     requestBody:
    *       required: true
    *       content:
    *         multipart/form-data:
    *           schema:
    *             type: object
-   *             required:
-   *               - contractId
-   *               - files
    *             properties:
-   *               contractId:
-   *                 type: integer
-   *                 description: 계약 ID
-   *                 example: 1
    *               files:
    *                 type: array
-   *                 items:
-   *                   type: string
-   *                   format: binary
-   *                 maxItems: 10
-   *                 description: 업로드할 파일들 (최대 10개, 각 10MB)
+   *                 items: { type: string, format: binary }
    *     responses:
-   *       200:
-   *         description: 계약서 업로드 성공
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: object
-   *               properties:
-   *                 message:
-   *                   type: string
-   *                   example: "계약서 업로드 성공"
-   *                 contractDocumentId:
-   *                   type: integer
-   *       400:
-   *         description: 잘못된 요청
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: object
-   *               properties:
-   *                 message:
-   *                   type: string
-   *                   example: "파일이 없습니다"
-   *       401:
-   *         description: 인증이 필요합니다
+   *       201:
+   *         description: 업로드 성공
    */
-  // 계약서 업로드
-  router.post(
-    '/upload',
-    isAuthenticated,
-    upload.single('file'), // 최대 10개 파일
-
-    contractDocumentsController.uploadContractDocuments,
-  );
+  router.post('/:contractId/upload', isAuthenticated, upload.any(), ctl.uploadContractDocuments);
 
   /**
    * @swagger
    * /contractDocuments/{contractDocumentId}/download:
    *   get:
-   *     tags:
-   *       - ContractDocuments
-   *     summary: 계약서 다운로드
-   *     description: 단일 계약서 파일 다운로드
-   *     security:
-   *       - bearerAuth: []
+   *     tags: [ContractDocuments]
+   *     summary: 단일 문서 다운로드
+   *     security: [{ bearerAuth: [] }]
    *     parameters:
    *       - in: path
    *         name: contractDocumentId
    *         required: true
-   *         schema:
-   *           type: integer
-   *         description: 다운로드할 계약서 ID
+   *         schema: { type: integer }
    *     responses:
    *       200:
-   *         description: 계약서 다운로드 성공
+   *         description: 파일 스트림
    *         content:
    *           application/octet-stream:
-   *             schema:
-   *               type: string
-   *               format: binary
-   *       401:
-   *         description: 인증이 필요합니다
+   *             schema: { type: string, format: binary }
    *       404:
-   *         description: 계약서를 찾을 수 없습니다
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: object
-   *               properties:
-   *                 message:
-   *                   type: string
-   *                   example: "계약서를 찾을 수 없습니다"
+   *         description: 문서를 찾을 수 없음
    */
-
-  // 계약서 다운로드
-  router.get(
-    '/:contractDocumentId/download',
-    isAuthenticated,
-    contractDocumentsController.downloadSingleDocument,
-  );
+  router.get('/:contractDocumentId/download', isAuthenticated, ctl.downloadSingleDocument);
 
   /**
    * @swagger
    * /contractDocuments/download:
    *   post:
-   *     tags:
-   *       - ContractDocuments
-   *     summary: 계약서 다중 다운로드
-   *     description: 여러 계약서를 ZIP 파일로 다운로드
-   *     security:
-   *       - bearerAuth: []
+   *     tags: [ContractDocuments]
+   *     summary: 다중 문서 ZIP 다운로드
+   *     security: [{ bearerAuth: [] }]
    *     requestBody:
    *       required: true
    *       content:
    *         application/json:
    *           schema:
    *             type: object
-   *             required:
-   *               - contractDocumentIds
+   *             required: [contractDocumentIds]
    *             properties:
    *               contractDocumentIds:
    *                 type: array
-   *                 items:
-   *                   type: integer
-   *                 description: 다운로드할 계약서 ID 목록
-   *                 example: [1, 2, 3]
+   *                 items: { type: integer }
+   *                 example: [1,2,3]
    *     responses:
    *       200:
-   *         description: 계약서 다운로드 성공
+   *         description: zip 파일
    *         content:
    *           application/zip:
-   *             schema:
-   *               type: string
-   *               format: binary
-   *       400:
-   *         description: 잘못된 요청
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: object
-   *               properties:
-   *                 message:
-   *                   type: string
-   *                   example: "계약서 ID 목록이 필요합니다"
-   *       401:
-   *         description: 인증이 필요합니다
-   *       404:
-   *         description: 계약서를 찾을 수 없습니다
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: object
-   *               properties:
-   *                 message:
-   *                   type: string
-   *                   example: "일부 계약서를 찾을 수 없습니다"
+   *             schema: { type: string, format: binary }
    */
+  router.post('/download', isAuthenticated, ctl.downloadMultipleDocuments);
 
-  // 여러 계약서 다운로드
-  router.post(
-    '/download',
+  /**
+   * @swagger
+   * /contractDocuments/{contractId}:
+   *   patch:
+   *     tags: [ContractDocuments]
+   *     summary: 계약서 수정(삭제 + 추가)
+   *     description: |
+   *       - 삭제: `deleteDocumentIds`에 [1,2] 또는 "1,2" 형태 허용  
+   *       - 추가: multipart/form-data로 파일 업로드  
+   *     security: [{ bearerAuth: [] }]
+   *     parameters:
+   *       - in: path
+   *         name: contractId
+   *         required: true
+   *         schema: { type: integer }
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         multipart/form-data:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               deleteDocumentIds:
+   *                 oneOf:
+   *                   - type: array
+   *                     items: { type: integer }
+   *                     example: [10, 11]
+   *                   - type: string
+   *                     example: "10,11"
+   *               files:
+   *                 type: array
+   *                 items: { type: string, format: binary }
+   *                 description: 추가할 파일(선택)
+   *     responses:
+   *       200:
+   *         description: 수정 성공
+   *       400:
+   *         description: 잘못된 요청(계약 불일치/제한 초과 등)
+   */
+  router.patch(
+    '/:contractId',
     isAuthenticated,
-    validateDto(DownloadContractDocumentsDto),
-    contractDocumentsController.downloadMultipleDocuments,
+    upload.any(),
+    validateDto(EditContractDocumentsDto),
+    ctl.editContractDocuments,
   );
 
   return router;

--- a/src/contract-documents/controller.ts
+++ b/src/contract-documents/controller.ts
@@ -1,171 +1,210 @@
+/* eslint-disable */
 import { Request, Response, NextFunction } from 'express';
 import ContractDocumentsService from './service';
 import GetContractDocumentsDto from './dto/get-contract-documents.dto';
+import EditContractDocumentsDto from './dto/edit-contract-documents.dto';
 import UploadContractDocumentDto from './dto/upload-contract-document.dto';
-import DownloadContractDocumentsDto from './dto/download-contract-documents.dto';
 
-// Multer 파일 타입 정의
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace Express {
-    // eslint-disable-next-line no-shadow
-    interface Request {
-      file?: Multer.File;
-      files?: Multer.File[] | { [fieldname: string]: Multer.File[] };
-    }
+// 문자열/숫자/undefined 무엇이 와도 number로 시도, 실패하면 undefined
+const toNumber = (v: unknown): number | undefined => {
+  if (v == null) return undefined;
+  const n = Number((v as any).toString().trim());
+  return Number.isFinite(n) ? n : undefined;
+};
+
+// multer 결과를 어떤 형태(any/array/fields/single)로 받더라도 File[]로 표준화
+const collectMulterFiles = (req: Request): Express.Multer.File[] => {
+  const rf = req.files as unknown;
+
+  if (Array.isArray(rf)) {
+    return rf as Express.Multer.File[];
   }
-}
-// Express의 기본 Request 타입 사용 (index.d.ts에서 확장된 타입)
+  if (rf && typeof rf === 'object') {
+    const acc: Express.Multer.File[] = [];
+    for (const v of Object.values(rf as Record<string, unknown>)) {
+      if (Array.isArray(v)) for (const it of v) if (it) acc.push(it as Express.Multer.File);
+    }
+    return acc;
+  }
+  const single = (req as any).file as Express.Multer.File | undefined;
+  return single ? [single] : [];
+};
+
 export default class ContractDocumentsController {
-  // eslint-disable-next-line no-empty-function
-  constructor(private readonly contractDocumentsService: ContractDocumentsService) {}
+  constructor(private readonly service: ContractDocumentsService) {}
 
-  // 화살표 함수를 사용하여 this 바인딩 문제 해결
-  getContractDocuments = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  // 목록
+  getContractDocuments = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { companyId } = req.user!;
-      const query = req.query as unknown as GetContractDocumentsDto;
+      if (!req.user) {
+        res.status(401).json({ message: '인증이 필요합니다.' });
+        return;
+      }
+      const { companyId } = req.user;
+      const dto = req.query as unknown as GetContractDocumentsDto;
 
-      const result = await this.contractDocumentsService.getContractDocuments(companyId, query);
-
+      const result = await this.service.getContractDocuments(companyId, dto);
       res.status(200).json(result);
-    } catch (error) {
-      next(error);
+    } catch (err) {
+      next(err as Error);
     }
   };
 
-  // ✨ 새로운 메서드: 계약서 추가용 계약 목록 조회
-  getContractsForDraft = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  // 드래프트(드롭다운) 목록
+  getDraftContractsForDropdown = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { companyId } = req.user!;
-
-      const result = await this.contractDocumentsService.getContractsForDraft(companyId);
-
-      res.status(200).json(result);
-    } catch (error) {
-      next(error);
+      if (!req.user) { res.status(401).json({ message: '인증이 필요합니다.' }); return; }
+      const { companyId } = req.user;
+      const rows = await this.service.getDraftContractsForDropdown(companyId);
+      res.status(200).json(rows);
+    } catch (err) {
+      next(err as Error);
     }
   };
 
-  uploadContractDocuments = async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
+  // (선택) 단순 드래프트 목록
+  getDraftContracts = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { companyId, id: userId } = req.user!;
-      // const { contractId } = req.body as UploadContractDocumentDto;
-      const file = req.file as Express.Multer.File;
+      if (!req.user) { res.status(401).json({ message: '인증이 필요합니다.' }); return; }
+      const { companyId } = req.user;
+      const rows = await this.service.getDraftContracts(companyId);
+      res.status(200).json(rows);
+    } catch (err) {
+      next(err as Error);
+    }
+  };
 
-      if (!file || file.size === 0) {
+  // 업로드
+  uploadContractDocuments = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (!req.user) {
+        res.status(401).json({ message: '인증이 필요합니다.' });
+        return;
+      }
+      const { companyId, id: userId } = req.user;
+
+      // 다양한 위치/키에서 contractId 수집
+      const fromParam = toNumber((req.params as any)?.contractId);
+      const fromBody = toNumber((req.body as Partial<UploadContractDocumentDto> | any)?.contractId);
+      const fromQuery = toNumber((req.query as any)?.contractId);
+      const fromAlt =
+        toNumber((req.body as any)?.selectedContractId) ??
+        toNumber((req.body as any)?.dealId) ??
+        toNumber((req.body as any)?.deal_id) ??
+        toNumber((req.body as any)?.contract_id);
+
+      let useContractId = fromParam ?? fromBody ?? fromQuery ?? fromAlt;
+
+      // 하나도 없으면: 진행중 드래프트가 1건일 때 자동 선택
+      if (useContractId == null) {
+        const auto = await this.service.resolveContractIdForUpload(companyId, userId);
+        if (typeof auto === 'number' && Number.isFinite(auto)) useContractId = auto;
+      }
+
+      if (typeof useContractId !== 'number' || !Number.isFinite(useContractId) || useContractId <= 0) {
+        res.status(400).json({
+          message:
+            '계약 ID를 찾을 수 없습니다. 진행 중인 계약이 1건일 때만 자동 선택됩니다. 계약을 선택한 뒤 업로드해주세요.',
+        });
+        return;
+      }
+
+      const files = collectMulterFiles(req);
+      if (files.length === 0) {
         res.status(400).json({ message: '업로드할 파일이 없습니다.' });
         return;
       }
 
-      const result = await this.contractDocumentsService.uploadContractDocuments(
-        companyId,
-        userId,
-        file,
-      );
-
-      res.status(200).json({
-        message: '계약서 업로드 성공',
-        contractDocumentId: result.contractDocumentId,
-      });
-    } catch (error) {
-      next(error);
+      const result = await this.service.uploadContractDocuments(companyId, userId, useContractId, files);
+      res.status(201).json({ message: '계약서 업로드 성공', contractDocumentId: result.contractDocumentId });
+    } catch (err) {
+      next(err as Error);
     }
   };
 
-  downloadSingleDocument = async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
+  // 단일 다운로드
+  downloadSingleDocument = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { companyId } = req.user!;
-      const { contractDocumentId } = req.params;
+      if (!req.user) { res.status(401).json({ message: '인증이 필요합니다.' }); return; }
+      const { companyId } = req.user;
 
-      const document = await this.contractDocumentsService.getDocumentForDownload(
-        companyId,
-        parseInt(contractDocumentId || '0', 10),
-      );
+      const contractDocumentId = toNumber((req.params as any)?.contractDocumentId);
+      if (!contractDocumentId) {
+        res.status(400).json({ message: '유효한 문서 ID가 아닙니다.' });
+        return;
+      }
 
-      res.setHeader('Content-Type', document.fileType);
+      const doc = await this.service.getDocumentForDownload(companyId, contractDocumentId);
+
+      const filename = (doc.fileName ?? 'download').trim() || 'download';
+      const fallback = filename.replace(/[^\x20-\x7E]/g, '_');
+
+      res.setHeader('Content-Type', doc.fileType);
       res.setHeader(
         'Content-Disposition',
-        `attachment; filename="${encodeURIComponent(document.fileName)}"`,
+        `attachment; filename="${fallback}"; filename*=UTF-8''${encodeURIComponent(filename)}`,
       );
-      res.sendFile(document.filePath);
-    } catch (error) {
-      next(error);
+      res.sendFile(doc.filePath);
+    } catch (err) {
+      next(err as Error);
     }
   };
 
-  downloadMultipleDocuments = async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
+  // ZIP 다중 다운로드
+  downloadMultipleDocuments = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { companyId } = req.user!;
-      const { contractDocumentIds } = req.body as DownloadContractDocumentsDto;
+      if (!req.user) { res.status(401).json({ message: '인증이 필요합니다.' }); return; }
+      const { companyId } = req.user;
 
-      const zipBuffer = await this.contractDocumentsService.downloadMultipleDocuments(
-        companyId,
-        contractDocumentIds,
-      );
+      const body = req.body as { contractDocumentIds?: number[] };
+      const ids = Array.isArray(body?.contractDocumentIds)
+        ? body.contractDocumentIds
+        : [];
 
+      if (!ids.length) {
+        res.status(400).json({ message: '다운로드할 문서를 선택해주세요.' });
+        return;
+      }
+
+      const zip = await this.service.downloadMultipleDocuments(companyId, ids);
       res.setHeader('Content-Type', 'application/zip');
-      res.setHeader('Content-Disposition', 'attachment; filename="contract-documents.zip"');
-      res.send(zipBuffer);
-    } catch (error) {
-      next(error);
+      res.setHeader('Content-Disposition', 'attachment; filename="documents.zip"');
+      res.status(200).send(zip);
+    } catch (err) {
+      next(err as Error);
     }
   };
 
-  // ❌ editContractDocuments 메서드 제거됨 - 이제 계약 API에서 처리
+  // 수정(삭제/추가)
+  editContractDocuments = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (!req.user) { res.status(401).json({ message: '인증이 필요합니다.' }); return; }
+      const { companyId, id: userId } = req.user;
 
-  // ✨ 새로운 메서드들: 계약 API에서 내부적으로 호출할 헬퍼 메서드들
-  // 이 메서드들은 HTTP 엔드포인트가 아니라 다른 서비스에서 직접 호출하는 메서드들입니다.
+      const contractId = toNumber((req.params as any)?.contractId) ?? 0;
+      if (!contractId) {
+        res.status(400).json({ message: '유효한 계약 ID가 아닙니다.' });
+        return;
+      }
 
-  /**
-   * 계약서를 계약에 연결 (계약 API 내부에서 호출)
-   */
-  async attachDocumentsToContract(
-    companyId: number,
-    contractId: number,
-    documentIds: number[],
-  ): Promise<void> {
-    return this.contractDocumentsService.attachDocumentsToContract(
-      companyId,
-      contractId,
-      documentIds,
-    );
-  }
+      // 삭제 ID는 number[]만 허용되도록 정규화
+      const raw = (req.body as EditContractDocumentsDto | any)?.deleteDocumentIds;
+      const rawArr: any[] = Array.isArray(raw) ? raw : raw != null ? [raw] : [];
+      const deleteIds = Array.from(
+        new Set(
+          rawArr
+            .flatMap((t) => (typeof t === 'string' ? t.split(',') : [t]))
+            .map((v) => Number(String(v).trim()))
+            .filter((n) => Number.isInteger(n) && n > 0),
+        ),
+      );
 
-  /**
-   * 계약서 파일명 업데이트 (계약 API 내부에서 호출)
-   */
-  async updateContractDocumentFileNames(
-    companyId: number,
-    contractId: number,
-    updates: { id: number; fileName?: string }[],
-  ): Promise<void> {
-    return this.contractDocumentsService.updateContractDocumentFileNames(
-      companyId,
-      contractId,
-      updates,
-    );
-  }
+      const files = collectMulterFiles(req);
 
-  /**
-   * 특정 계약의 계약서 목록 조회 (계약 API 내부에서 호출)
-   */
-  async getContractDocumentsByContractId(
-    companyId: number,
-    contractId: number,
-  ): Promise<{ id: number; fileName: string }[]> {
-    return this.contractDocumentsService.getContractDocumentsByContractId(companyId, contractId);
-  }
+      await this.service.editContractDocuments(companyId, userId, contractId, deleteIds, files);
+      res.status(200).json({ message: '계약서 수정 성공' });
+    } catch (err) {
+      next(err as Error);
+    }
+  };
 }

--- a/src/contract-documents/dto/get-draft-contracts.dto.ts
+++ b/src/contract-documents/dto/get-draft-contracts.dto.ts
@@ -1,0 +1,5 @@
+/* eslint-disable semi */
+export default interface GetDraftContractsDto {
+  keyword?: string;
+  boardOnly?: boolean;
+}

--- a/src/contract-documents/dto/upload-contract-document.dto.ts
+++ b/src/contract-documents/dto/upload-contract-document.dto.ts
@@ -1,9 +1,18 @@
-import { IsInt, IsNotEmpty } from 'class-validator';
+import { IsInt, Min, IsOptional } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export default class UploadContractDocumentDto {
-  @IsNotEmpty({ message: '계약 ID는 필수입니다.' })
+  @IsOptional() // ✅ 필수 → 선택
   @Type(() => Number)
   @IsInt({ message: '계약 ID는 정수여야 합니다.' })
-  contractId!: number;
+  @Min(1, { message: '계약 ID는 1 이상이어야 합니다.' })
+  contractId?: number;
+
+  // 멀터/프런트가 남길 수 있는 키들: 검증에서 허용(무시)
+  @IsOptional() files?: unknown;
+  @IsOptional() file?: unknown;
+  @IsOptional() documents?: unknown;
+  @IsOptional() ['files[]']?: unknown;
+  @IsOptional() ['file[]']?: unknown;
+  @IsOptional() ['documents[]']?: unknown;
 }

--- a/src/contract-documents/service.ts
+++ b/src/contract-documents/service.ts
@@ -3,31 +3,53 @@ import { ContractDocument } from '@prisma/client';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import archiver from 'archiver';
-import { Readable } from 'stream';
-import ContractDocumentsRepository from './repository';
+import ContractDocumentsRepository, { DraftContractRow } from './repository';
 import GetContractDocumentsDto from './dto/get-contract-documents.dto';
 import EmailService from '../common/email.service';
 import { NotFoundError } from '../common/errors/not-found-error';
 import { BadRequestError } from '../common/errors/bad-request-error';
 
+/** ---------- 헬퍼(클래스 밖) ---------- */
+
+const trimOrEmpty = (v?: string | null): string => (typeof v === 'string' ? v.trim() : '');
+
+const pickName = (documentName?: string | null, fileName?: string | null, fallback = ''): string => {
+  const a = trimOrEmpty(documentName);
+  if (a) return a;
+  const b = trimOrEmpty(fileName);
+  if (b) return b;
+  return fallback;
+};
+
+const toDateString = (d: Date | null | undefined): string => {
+  if (!(d instanceof Date)) return '';
+  const iso = d.toISOString();
+  const i = iso.indexOf('T');
+  return i >= 0 ? iso.slice(0, i) : iso;
+};
+
+const buildLabel = (r: DraftContractRow): string => {
+  const carNumber = r.car?.carNumber ?? '';
+  const model = r.car?.model ?? '';
+  const name = r.customer?.name ?? '';
+  const parts: string[] = [];
+  if (carNumber) parts.push(`[${carNumber}]`);
+  if (name) parts.push(name);
+  if (model) parts.push(model);
+  return parts.join(' ').trim();
+};
+
 interface ContractDocumentWithRelations extends ContractDocument {
   contract: {
     id: number;
     contractDate: Date | null;
-    user: {
-      name: string;
-    };
-    car: {
-      carNumber: string;
-    };
-    customer: {
-      email: string;
-      name: string;
-    };
-  };
+    user: { name: string } | null;
+    car: { carNumber: string } | null;
+    customer: { email: string | null; name: string | null } | null;
+  } | null;
 }
 
-interface Document {
+interface DocumentListItem {
   id: number;
   fileName: string;
 }
@@ -39,7 +61,7 @@ interface ContractDocumentListItem {
   documentsCount: number;
   manager: string;
   carNumber: string;
-  documents: Document[];
+  documents: DocumentListItem[];
 }
 
 interface PaginatedResult {
@@ -49,30 +71,26 @@ interface PaginatedResult {
   data: ContractDocumentListItem[];
 }
 
-// ✨ 새로운 인터페이스: 계약서 추가용 계약 목록
-interface ContractForDraftItem {
-  id: number;
-  data: string;
-}
+/** ---------- 서비스 구현 ---------- */
 
 export default class ContractDocumentsService {
   private readonly emailService: EmailService;
+
   private readonly allowedExtensions = ['.pdf', '.doc', '.docx', '.jpg', '.jpeg', '.png', '.csv'];
+
   private readonly maxFileSize = 10 * 1024 * 1024; // 10MB
+
   private readonly maxFileCount = 10;
 
-  constructor(private readonly contractDocumentsRepository: ContractDocumentsRepository) {
+  constructor(private readonly repo: ContractDocumentsRepository) {
     this.emailService = new EmailService();
   }
 
-  async getContractDocuments(
-    companyId: number,
-    dto: GetContractDocumentsDto,
-  ): Promise<PaginatedResult> {
+  /** 목록 */
+  async getContractDocuments(companyId: number, dto: GetContractDocumentsDto): Promise<PaginatedResult> {
     const { page = 1, pageSize = 8, keyword, searchBy } = dto;
-    const offset = (page - 1) * pageSize;
 
-    const { documents, total } = await this.contractDocumentsRepository.findContractDocuments(
+    const { documents, total } = await this.repo.findContractDocuments(
       companyId,
       page,
       pageSize,
@@ -80,8 +98,8 @@ export default class ContractDocumentsService {
       searchBy,
     );
 
-    const groupedDocuments = this.groupDocumentsByContract(documents);
-    const data = this.formatContractDocumentList(groupedDocuments);
+    const grouped = this.groupByContract(documents as ContractDocumentWithRelations[]);
+    const data = this.formatList(grouped);
 
     return {
       currentPage: page,
@@ -91,282 +109,280 @@ export default class ContractDocumentsService {
     };
   }
 
-  // ✨ 새로운 메서드: 계약서 추가용 계약 목록 조회
-  async getContractsForDraft(companyId: number): Promise<ContractForDraftItem[]> {
-    const contracts = await this.contractDocumentsRepository.findContractsForDraft(companyId);
-
-    return contracts.map((contract) => ({
-      id: contract.id,
-      data: `${contract.car.model} - ${contract.customer?.name || '고객정보없음'}`,
-    }));
-  }
-
+  /** 업로드 */
   async uploadContractDocuments(
     companyId: number,
     userId: number,
-    file: Express.Multer.File,
+    contractId: number,
+    files: Express.Multer.File[],
   ): Promise<{ contractDocumentId: number }> {
-    // 업로드된 파일 경로 추적을 위한 배열
     const uploadedFilePaths: string[] = [];
-    let savedDocument: ContractDocument | null = null;
+    let saved: ContractDocument[] = [];
 
     try {
-      // 파일 유효성 검증
-      this.validateFiles([file]);
+      this.validateFiles(files);
 
-      // 파일이 실제로 저장되었는지 확인
+      const contract = await this.repo.findContractById(contractId, companyId);
+      if (!contract) throw new NotFoundError('계약을 찾을 수 없습니다.');
 
-      try {
-        await fs.access(file.path);
-        uploadedFilePaths.push(file.path);
-      } catch (error) {
-        throw new Error(`파일 저장 실패: ${file.originalname}`);
+      const existing = await this.repo.countDocumentsByContract(contractId);
+      if (existing + files.length > this.maxFileCount) {
+        throw new BadRequestError(`계약서는 최대 ${this.maxFileCount}개까지 업로드 가능합니다.`);
       }
 
-      // 트랜잭션으로 문서 저장
+      // 실제 저장 확인
+      for (const f of files) {
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          await fs.access(f.path);
+          uploadedFilePaths.push(f.path);
+        } catch {
+          throw new Error(`파일 저장 실패: ${f.originalname}`);
+        }
+      }
+
       try {
-        savedDocument = await this.contractDocumentsRepository.createContractDocument(userId, file);
-      } catch (dbError) {
-        // DB 저장 실패 시 파일 시스템에서 파일 삭제
+        saved = await this.repo.createContractDocuments(contractId, userId, files);
+      } catch {
         await this.cleanupFiles(uploadedFilePaths);
         throw new Error('데이터베이스 저장 중 오류가 발생했습니다.');
       }
 
-      // 저장된 문서가 있는지 확인
-      if (!savedDocument) {
+      if (!saved.length || !saved[0]) {
         await this.cleanupFiles(uploadedFilePaths);
         throw new Error('계약 문서 저장에 실패했습니다.');
       }
 
-      // const firstDocument = savedDocuments[0];
-      // if (!firstDocument) {
-      //   await this.cleanupFiles(uploadedFilePaths);
-      //   throw new Error('계약 문서 저장에 실패했습니다.');
-      //
-
-      // // 이메일 발송 (실패해도 롤백하지 않음 - 이메일은 부가 기능)
-      // if (contract.customer?.email) {
-      //   try {
-      //     await this.sendContractEmail(contract, files);
-      //   } catch (emailError) {
-      //     console.error('이메일 발송 실패:', emailError);
-      //     // 이메일 실패는 무시하고 진행
-      //   }
-      // }
-
-      return { contractDocumentId: savedDocument.id };
-    } catch (error) {
-      // 오류 발생 시 업로드된 파일들 정리
-      if (uploadedFilePaths.length > 0) {
-        await this.cleanupFiles(uploadedFilePaths);
+      // 이메일(부가 기능)
+      if (contract.customer?.email) {
+        try {
+          await this.sendContractEmail(contract as any, files);
+        } catch (e) {
+          // 이메일 실패는 무시
+          // eslint-disable-next-line no-console
+          console.error('이메일 발송 실패:', e);
+        }
       }
 
-      // 만약 DB에 일부 저장되었다면 삭제 처리
-      // if (savedDocuments.length > 0) {
-      //   const documentIds = savedDocuments.map((doc) => doc.id);
-      //   try {
-      //     await this.contractDocumentsRepository.deleteDocuments(documentIds);
-      //   } catch (rollbackError) {
-      //     console.error('데이터베이스 롤백 실패:', rollbackError);
-      //   }
-      // }
-
-      throw error;
+      return { contractDocumentId: saved[0].id };
+    } catch (err) {
+      if (uploadedFilePaths.length) await this.cleanupFiles(uploadedFilePaths);
+      if (saved.length) {
+        const ids = saved.map((d) => d.id);
+        try {
+          await this.repo.deleteDocuments(ids, companyId);
+        } catch (rollbackError) {
+          // eslint-disable-next-line no-console
+          console.error('데이터베이스 롤백 실패:', rollbackError);
+        }
+      }
+      throw err;
     }
   }
 
-  // ✨ 새로운 메서드: 계약 API에서 사용할 계약서 관리 메서드들
-  /**
-   * 계약서 파일들을 특정 계약에 연결
-   * 계약 수정 API에서 호출됨
-   */
-  async attachDocumentsToContract(
+  /** 수정(삭제/추가) */
+  async editContractDocuments(
     companyId: number,
+    userId: number,
     contractId: number,
-    documentIds: number[],
+    deleteDocumentIds?: number[],
+    newFiles?: Express.Multer.File[],
   ): Promise<void> {
-    if (!documentIds || documentIds.length === 0) {
-      return;
+    const contract = await this.repo.findContractById(contractId, companyId);
+    if (!contract) throw new NotFoundError('계약을 찾을 수 없습니다.');
+
+    // 삭제
+    const ids = Array.isArray(deleteDocumentIds)
+      ? Array.from(new Set(deleteDocumentIds.filter((n) => Number.isInteger(n) && n > 0)))
+      : [];
+
+    if (ids.length) {
+      const docs = await this.repo.findDocumentsByIds(ids, companyId);
+      const invalid = docs.filter((d) => d.contractId !== contractId);
+      if (invalid.length) throw new BadRequestError('삭제하려는 문서가 해당 계약과 연결되어 있지 않습니다.');
+
+      await Promise.all(docs.map((d) => this.deleteFile(d.filePath)));
+      const deleted = await this.repo.deleteDocuments(ids, companyId);
+      if (deleted === 0) throw new NotFoundError('삭제할 문서를 찾을 수 없습니다.');
     }
 
-    // 계약 존재 확인
-    const contract = await this.contractDocumentsRepository.findContractById(contractId, companyId);
-    if (!contract) {
-      throw new NotFoundError('계약을 찾을 수 없습니다.');
+    // 추가
+    if (newFiles && newFiles.length) {
+      this.validateFiles(newFiles);
+      const current = await this.repo.countDocumentsByContract(contractId);
+      const remain = current - ids.length;
+      if (remain + newFiles.length > this.maxFileCount) {
+        throw new BadRequestError(`계약서는 최대 ${this.maxFileCount}개까지 업로드 가능합니다.`);
+      }
+      await this.repo.createContractDocuments(contractId, userId, newFiles);
     }
-
-    // 문서들이 해당 회사에 속하는지 확인
-    const documents = await this.contractDocumentsRepository.findDocumentsByIds(
-      documentIds,
-      companyId,
-    );
-
-    const foundIds = documents.map((doc) => doc.id);
-    const missingIds = documentIds.filter((id) => !foundIds.includes(id));
-
-    if (missingIds.length > 0) {
-      throw new BadRequestError(`존재하지 않는 계약서 ID: ${missingIds.join(', ')}`);
-    }
-
-    // 문서들을 해당 계약에 연결
-    await this.contractDocumentsRepository.attachDocumentsToContract(contractId, documentIds);
   }
 
-  /**
-   * 계약의 계약서 파일명 업데이트
-   * 계약 수정 API에서 호출됨
-   */
-  async updateContractDocumentFileNames(
+  /** 단일 다운로드용 메타 */
+  async getDocumentForDownload(
     companyId: number,
-    contractId: number,
-    updates: { id: number; fileName?: string }[],
-  ): Promise<void> {
-    if (!updates || updates.length === 0) {
-      return;
+    contractDocumentId: number,
+  ): Promise<{ filePath: string; fileName: string; fileType: string }> {
+    const doc = await this.repo.findDocumentById(contractDocumentId, companyId);
+    if (!doc) throw new NotFoundError('문서를 찾을 수 없습니다.');
+
+    const fileName = pickName((doc as any).documentName, doc.fileName, 'download');
+    const ext = path.extname(doc.fileName ?? fileName).toLowerCase();
+
+    let fileType = 'application/octet-stream';
+    if (ext === '.pdf') fileType = 'application/pdf';
+    else if (ext === '.doc') fileType = 'application/msword';
+    else if (ext === '.docx') fileType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    else if (ext === '.jpg' || ext === '.jpeg') fileType = 'image/jpeg';
+    else if (ext === '.png') fileType = 'image/png';
+    else if (ext === '.csv') fileType = 'text/csv';
+
+    // 존재 확인
+    try {
+      await fs.access(doc.filePath);
+    } catch {
+      throw new NotFoundError('파일을 찾을 수 없습니다.');
     }
 
-    // 계약 존재 확인
-    const contract = await this.contractDocumentsRepository.findContractById(contractId, companyId);
-    if (!contract) {
-      throw new NotFoundError('계약을 찾을 수 없습니다.');
+    return { filePath: doc.filePath, fileName, fileType };
+  }
+
+  /** ZIP */
+  async downloadMultipleDocuments(companyId: number, ids: number[]): Promise<Buffer> {
+    if (!ids?.length) throw new BadRequestError('다운로드할 문서를 선택해주세요.');
+
+    const docs = await this.repo.findDocumentsByIds(ids, companyId);
+    if (!docs.length) throw new NotFoundError('문서를 찾을 수 없습니다.');
+
+    const valid: ContractDocument[] = [];
+    for (const d of docs) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await fs.access(d.filePath);
+        valid.push(d as any);
+      } catch {
+        // eslint-disable-next-line no-console
+        console.error(`파일을 찾을 수 없음: ${d.filePath}`);
+      }
     }
+    if (!valid.length) throw new NotFoundError('다운로드 가능한 파일이 없습니다.');
 
-    const documentIds = updates.map((u) => u.id);
-    const documents = await this.contractDocumentsRepository.findDocumentsByIds(
-      documentIds,
-      companyId,
-    );
+    return this.createZipFile(valid);
+  }
 
-    // 모든 문서가 해당 계약에 속하는지 확인
-    const invalidDocs = documents.filter((doc) => doc.contractId !== contractId);
-    if (invalidDocs.length > 0) {
-      throw new BadRequestError('일부 계약서가 해당 계약에 속하지 않습니다.');
-    }
+  /** 드래프트 라벨 목록 (프런트 드롭다운) */
+  async getDraftContracts(companyId: number) {
+    const rows = await this.repo.findDraftContracts(companyId);
+    return rows.map((r) => ({ id: r.id, name: buildLabel(r) }));
+  }
 
-    // 파일명 업데이트
-    for (const update of updates) {
-      if (update.fileName) {
-        await this.contractDocumentsRepository.updateDocumentFileName(update.id, update.fileName);
+  /** 동일하지만 data 키를 쓰는 스펙 */
+  async getDraftContractsForDropdown(companyId: number): Promise<Array<{ id: number; data: string }>> {
+    const rows = await this.repo.findDraftContracts(companyId);
+    return rows.map((r) => ({ id: r.id, data: buildLabel(r) }));
+  }
+
+  /** 드래프트 자동 선택 후보 */
+  async resolveContractIdForUpload(companyId: number, userId: number): Promise<number | null> {
+    const drafts = await this.repo.findDraftContracts(companyId);
+    if (!Array.isArray(drafts) || drafts.length === 0) return null;
+
+    const mine = drafts.filter((d) => d.userId === userId);
+    if (mine.length >= 1) return mine[0]?.id ?? null;
+
+    return drafts[0]?.id ?? null;
+  }
+
+  /** ---------------- 내부 유틸 ---------------- */
+
+  private validateFiles(files: Express.Multer.File[]): void {
+    for (const f of files) {
+      const ext = path.extname(f.originalname).toLowerCase();
+      if (!this.allowedExtensions.includes(ext)) {
+        throw new BadRequestError(`허용되지 않은 파일 형식입니다: ${ext}`);
+      }
+      if (f.size > this.maxFileSize) {
+        throw new BadRequestError(`파일 크기는 10MB를 초과할 수 없습니다: ${f.originalname}`);
       }
     }
   }
 
-  /**
-   * 계약에 속한 모든 계약서 조회 (계약 API용)
-   */
-  async getContractDocumentsByContractId(
-    companyId: number,
-    contractId: number,
-  ): Promise<{ id: number; fileName: string }[]> {
-    const documents = await this.contractDocumentsRepository.findDocumentsByContractId(
-      contractId,
-      companyId,
-    );
-    return documents.map((doc) => ({
-      id: doc.id,
-      fileName: doc.fileName,
-    }));
-  }
-
-  // 파일 정리를 위한 헬퍼 메서드 추가
   private async cleanupFiles(filePaths: string[]): Promise<void> {
     const errors: Error[] = [];
-
-    for (const filePath of filePaths) {
+    for (const p of filePaths) {
       try {
-        await fs.unlink(filePath);
-        console.log(`파일 삭제 완료: ${filePath}`);
-      } catch (error) {
-        console.error(`파일 삭제 실패: ${filePath}`, error);
-        errors.push(error as Error);
+        // eslint-disable-next-line no-await-in-loop
+        await fs.unlink(p);
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(`파일 삭제 실패: ${p}`, e);
+        errors.push(e as Error);
       }
     }
-
-    if (errors.length > 0) {
+    if (errors.length) {
+      // eslint-disable-next-line no-console
       console.error(`${errors.length}개의 파일 삭제 실패`);
     }
   }
 
-  private validateFiles(files: Express.Multer.File[]): void {
-    for (const file of files) {
-      // 확장자 검증
-      const ext = path.extname(file.originalname).toLowerCase();
-      if (!this.allowedExtensions.includes(ext)) {
-        throw new BadRequestError(`허용되지 않은 파일 형식입니다: ${ext}`);
-      }
-
-      // 파일 크기 검증
-      if (file.size > this.maxFileSize) {
-        throw new BadRequestError(`파일 크기는 10MB를 초과할 수 없습니다: ${file.originalname}`);
-      }
+  private groupByContract(docs: ContractDocumentWithRelations[]) {
+    const m = new Map<number, ContractDocumentWithRelations[]>();
+    for (const doc of docs) {
+      const id = doc.contractId;
+      const arr = m.get(id);
+      if (arr) arr.push(doc);
+      else m.set(id, [doc]);
     }
+    return m;
   }
 
-  private groupDocumentsByContract(
-    documents: ContractDocumentWithRelations[],
-  ): Map<number, ContractDocumentWithRelations[]> {
-    const grouped = new Map<number, ContractDocumentWithRelations[]>();
+  private formatList(grouped: Map<number, ContractDocumentWithRelations[]>): ContractDocumentListItem[] {
+    const out: ContractDocumentListItem[] = [];
 
-    for (const doc of documents) {
-      const { contractId } = doc;
-      if (!contractId) {
-        continue; // 계약 ID가 없는 문서는 무시
-      }
-      if (!grouped.has(contractId)) {
-        grouped.set(contractId, []);
-      }
-      grouped.get(contractId)!.push(doc);
-    }
+    for (const [contractId, docs] of grouped) {
+      if (!docs || docs.length === 0) continue;
 
-    return grouped;
-  }
+      const first = docs[0]!;
+      const contractName = pickName((first as any).documentName, first.fileName, `계약서_${contractId}`);
+      const resolutionDate = toDateString(first.contract?.contractDate);
 
-  private formatContractDocumentList(
-    groupedDocuments: Map<number, ContractDocumentWithRelations[]>,
-  ): ContractDocumentListItem[] {
-    const result: ContractDocumentListItem[] = [];
-
-    for (const [contractId, docs] of groupedDocuments) {
-      const firstDoc = docs[0];
-      if (!firstDoc) {
-        continue; // 또는 throw new Error('문서 없음');
-      }
-      const contractName = firstDoc.documentName || `계약서_${contractId}`;
-      const documents = docs.map((doc) => ({
-        id: doc.id,
-        fileName: doc.fileName,
+      const documents = docs.map((d) => ({
+        id: d.id,
+        fileName: pickName((d as any).documentName, d.fileName, ''),
       }));
 
-      result.push({
+      out.push({
         id: contractId,
         contractName,
-        resolutionDate: firstDoc.contract.contractDate?.toISOString().split('T')[0] ?? '', //  null 또는 undefined일 경우 '' 반환
+        resolutionDate,
         documentsCount: docs.length,
-        manager: firstDoc.contract.user.name,
-        carNumber: firstDoc.contract.car.carNumber,
-        documents: documents,
+        manager: trimOrEmpty(first.contract?.user?.name) || '',
+        carNumber: trimOrEmpty(first.contract?.car?.carNumber) || '',
+        documents,
       });
     }
 
-    return result;
+    return out;
   }
 
-  private async createZipFile(documents: ContractDocument[]): Promise<Buffer> {
+  private async createZipFile(docs: ContractDocument[]): Promise<Buffer> {
     const archive = archiver('zip', { zlib: { level: 9 } });
     const chunks: Buffer[] = [];
 
     return new Promise((resolve, reject) => {
-      archive.on('data', (chunk) => chunks.push(chunk));
+      archive.on('data', (c) => chunks.push(c));
       archive.on('end', () => resolve(Buffer.concat(chunks)));
       archive.on('error', reject);
 
       (async () => {
-        for (const doc of documents) {
+        for (const d of docs) {
           try {
-            const fileBuffer = await fs.readFile(doc.filePath);
-            archive.append(fileBuffer, { name: doc.fileName });
-          } catch (error) {
-            console.error(`파일 읽기 실패: ${doc.filePath}`, error);
+            // eslint-disable-next-line no-await-in-loop
+            const buf = await fs.readFile(d.filePath);
+            archive.append(buf, { name: d.fileName });
+          } catch (e) {
+            // eslint-disable-next-line no-console
+            console.error(`파일 읽기 실패: ${d.filePath}`, e);
           }
         }
         await archive.finalize();
@@ -377,8 +393,9 @@ export default class ContractDocumentsService {
   private async deleteFile(filePath: string): Promise<void> {
     try {
       await fs.unlink(filePath);
-    } catch (error) {
-      console.error(`파일 삭제 실패: ${filePath}`, error);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(`파일 삭제 실패: ${filePath}`, e);
     }
   }
 
@@ -388,99 +405,10 @@ export default class ContractDocumentsService {
       <h2>안녕하세요, ${contract.customer.name}님</h2>
       <p>${contract.car.carNumber} 차량의 계약서가 등록되었습니다.</p>
       <p>첨부된 계약서를 확인해주세요.</p>
-      <br>
+      <br/>
       <p>감사합니다.</p>
     `;
-
-    const attachments = files.map((file) => ({
-      filename: file.originalname,
-      path: file.path,
-    }));
-
+    const attachments = files.map((f) => ({ filename: f.originalname, path: f.path }));
     await this.emailService.sendEmail(contract.customer.email, subject, html, attachments);
-  }
-  async getDocumentForDownload(
-    companyId: number,
-    contractDocumentId: number,
-  ): Promise<{ filePath: string; fileName: string; fileType: string }> {
-    const document = await this.contractDocumentsRepository.findDocumentById(
-      contractDocumentId,
-      companyId,
-    );
-
-    if (!document) {
-      throw new NotFoundError('문서를 찾을 수 없습니다.');
-    }
-
-    // 파일 존재 여부 확인
-    try {
-      await fs.access(document.filePath);
-    } catch (error) {
-      throw new NotFoundError('파일을 찾을 수 없습니다.');
-    }
-
-    // MIME 타입 결정
-    const ext = path.extname(document.fileName).toLowerCase();
-    let fileType = 'application/octet-stream';
-
-    switch (ext) {
-      case '.pdf':
-        fileType = 'application/pdf';
-        break;
-      case '.doc':
-        fileType = 'application/msword';
-        break;
-      case '.docx':
-        fileType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-        break;
-      case '.jpg':
-      case '.jpeg':
-        fileType = 'image/jpeg';
-        break;
-      case '.png':
-        fileType = 'image/png';
-        break;
-    }
-
-    return {
-      filePath: document.filePath,
-      fileName: document.fileName,
-      fileType,
-    };
-  }
-
-  async downloadMultipleDocuments(
-    companyId: number,
-    contractDocumentIds: number[],
-  ): Promise<Buffer> {
-    if (!contractDocumentIds || contractDocumentIds.length === 0) {
-      throw new BadRequestError('다운로드할 문서를 선택해주세요.');
-    }
-
-    const documents = await this.contractDocumentsRepository.findDocumentsByIds(
-      contractDocumentIds,
-      companyId,
-    );
-
-    if (documents.length === 0) {
-      throw new NotFoundError('문서를 찾을 수 없습니다.');
-    }
-
-    // 파일들이 실제로 존재하는지 확인
-    const validDocuments = [];
-    for (const doc of documents) {
-      try {
-        await fs.access(doc.filePath);
-        validDocuments.push(doc);
-      } catch (error) {
-        console.error(`파일을 찾을 수 없음: ${doc.filePath}`);
-      }
-    }
-
-    if (validDocuments.length === 0) {
-      throw new NotFoundError('다운로드 가능한 파일이 없습니다.');
-    }
-
-    return await this.createZipFile(validDocuments);
   }
 }


### PR DESCRIPTION
## 📌 작업 개요

* 계약서 업로드/수정/다운로드 흐름 안정화 및 데이터 정합성 개선
* `contractId` 인식 강화(여러 입력 경로 허용)와 삭제/다운로드 로직 보완

## 🔗 관련 이슈

* [ ] 파일 삭제 성공 메시지 대비 실제 미삭제
* [ ] 업로드/수정 시 `contractId` 인식 실패
* [ ] 드롭다운에 보드 비노출 계약까지 표시
* [ ] 목록에서 문서 개수·담당자 미표시

## ✅ 작업 내용

### 1) 업로드/수정(편집)

* `contractId` 추출 범위 확장

  * `params / body / query` + 대체키(`selectedContractId`, `dealId`, `deal_id`, `contract_id`, `contract`) 모두 수용
  * 진행 중 드래프트가 “정확히 1건”일 때만 서버에서 자동 선택(여러 건일 경우 자동선택 **안 함**)
* `deleteDocumentIds` 정규화

  * 문자열(`"1,2, 3"`)·배열 혼용 입력 허용 → 숫자배열로 정규화 + 중복 제거
* 삭제 로직 강화

  * 회사/계약 일치 검증 후 **물리 파일 삭제** + **DB soft-delete**(deletedAt)
  * 처리 결과 `{ deletedCount, addedCount }`로 반환(프론트 피드백 정확화)
* 파일 검증 고도화

  * 확장자 화이트리스트에 **CSV** 추가(`.pdf/.doc/.docx/.jpg/.jpeg/.png/.csv`)
  * 10MB 초과 차단
* 트랜잭션/롤백 경로 보완

  * DB 저장 실패 시 디스크에 저장된 파일 정리

### 2) 목록 API 응답 확장

* 그룹핑 후 계약 단위 아이템으로 반환
* 응답 필드 추가/정비

  * `documentsCount`(=표시용 문서 수), `filesCount`(프론트 호환 별칭), `manager`(담당자), `carNumber`(차량번호), `contractName`, `resolutionDate`
* null/optional 값 안전 처리

### 3) 다운로드 안정화

* 한글/공백 파일명 안전 헤더(`filename` + `filename*` RFC5987) 적용
* 존재 확인 후 `res.download()` 사용(헤더·스트리밍 일관성 확보)
* MIME 타입 자동 판별 개선(pdf/doc/docx/jpg/jpeg/png/csv)

### 4) 드롭다운(드래프트) 정책 반영

* “보드에 노출되는 상태”만 선택 노출되도록 필터(예: `CONTRACT_DRAFT`, `CONTRACT_IN_PROGRESS`)
* 최신 업데이트 순 정렬

### 5) 라우터/미들웨어

* `/:contractId`로 들어온 값은 body에 복사하는 **normalize** 미들웨어 추가(검증·로깅 일관성)

## 🧪 테스트 내용

* [x] **다운로드(단일)**: 한글 파일명 브라우저 저장 다이얼로그 정상 노출
* [x] **목록 필드**: `documentsCount | filesCount | manager | carNumber | resolutionDate` 프론트 렌더링 확인
* [x] **드롭다운**: 보드 노출 대상만 표시되는지 확인
* [x] **엣지**: 10MB 초과/미허용 확장자 업로드 차단, 존재하지 않는 문서/계약 요청 시 적절한 4xx 반환

## ⚠️ 특이사항 (미해결/후속 필요)

1. **프론트의 `contractId` 전달 이슈**

   * 현재 백엔드는 `params/body/query/대체키`까지 모두 수용하지만,
     드래프트가 여러 건인 경우 **자동선택을 하지 않습니다.**
   * **권장**: 업로드·수정 시 `FormData`에 `contractId` 명시 전달

     ```ts
     const fd = new FormData();
     fd.append('contractId', String(selectedContractId));
     fd.append('file', file);
     await axios.post('/contractDocuments/upload', fd);
     ```
   * 또는 **URL에 명시**: `POST /contractDocuments/:contractId/upload`

2. **드롭다운 소스 정책**

   * 백엔드는 “보드 노출 상태”만 필터링하도록 수정됨.
   * 보드 기준이 더 필요하면 프론트에서 추가 필터(검색/정렬) 적용 권장.

3. **응답 스키마 변경(추가) 안내 – Breaking은 아님**

   * 목록 아이템에 `documentsCount`, `filesCount`, `manager`, `carNumber`, `resolutionDate` **추가**
   * 수정 응답 `{ deletedCount, addedCount }` **추가**
   * 기존 필드는 유지

4. **다운로드(일괄 ZIP)**

   * 단일 다운로드는 안정화. ZIP 일괄 다운로드는 기존 엔드포인트와 호환되나,
     프론트 통합 모달과의 에러 핸들링/진행 표시 개선 필요

---

